### PR TITLE
Support logging configuration via --set values for onos-ric

### DIFF
--- a/onos-ric/Chart.yaml
+++ b/onos-ric/Chart.yaml
@@ -7,7 +7,7 @@ name: onos-ric
 description: ONOS Radio Access Network Intelligent Controller
 kubeVersion: ">=1.17.0"
 type: application
-version: 0.0.9
+version: 0.0.10
 appVersion: v0.6.9
 keywords:
   - onos

--- a/onos-ric/templates/configmap.yaml
+++ b/onos-ric/templates/configmap.yaml
@@ -34,5 +34,22 @@ data:
   logging.yaml: |-
 {{- if .Values.logging }}
     logging:
-{{ toYaml .Values.logging | indent 6 }}
+{{- if .Values.logging.loggers }}
+      loggers:
+{{- range $key, $value := .Values.logging.loggers }}
+        - {{ toYaml $value}}
+          name: {{ $key | quote }}
+{{- end }}
+{{- else }}
+      loggers: []
+{{- end }}
+{{- if .Values.logging.sinks }}
+      sinks:
+{{- range $key, $value := .Values.logging.sinks }}
+        - {{ toYaml $value}}
+          name: {{ $key | quote }}
+{{- end }}
+{{- else }}
+      sinks: []
+{{- end }}
 {{- end}}

--- a/onos-ric/values.yaml
+++ b/onos-ric/values.yaml
@@ -63,4 +63,6 @@ tolerations: []
 
 affinity: {}
 
-logging: {}
+logging:
+  loggers: {}
+  sinks: {}


### PR DESCRIPTION
Changes the logging configuration format to allow overrides via `--set` flags, e.g. `--set onos-ric.logging.loggers.store/indications.level=debug`