### PR TITLE
Support logging configuration via --set values for onos-ric

### DIFF
--- a/onos-ric/Chart.yaml
+++ b/onos-ric/Chart.yaml
@@ -7,7 +7,7 @@ name: onos-ric
 description: ONOS Radio Access Network Intelligent Controller
 kubeVersion: ">=1.17.0"
 type: application
-version: 0.0.9
+version: 0.0.10
 appVersion: v0.6.9
 keywords:
   - onos

--- a/onos-ric/templates/configmap.yaml
+++ b/onos-ric/templates/configmap.yaml
@@ -33,6 +33,5 @@ data:
         {{- end }}
   logging.yaml: |-
 {{- if .Values.logging }}
-    logging:
-{{ toYaml .Values.logging | indent 6 }}
+{{ toYaml .Values.logging | indent 4 }}
 {{- end}}


### PR DESCRIPTION
The logging configuration no longer has a root `logging` field.