### PR TITLE
Update sd-ran chart to use onos-ric 0.6.13

### DIFF
--- a/sd-ran/Chart.yaml
+++ b/sd-ran/Chart.yaml
@@ -32,15 +32,15 @@ dependencies:
     version: 0.4.0
   - name: onos-ric
     condition: import.onos-ric.enabled
-    repository: https://sdrancharts.onosproject.org
+    repository: "@sdran"
     version: 0.0.12
   - name: onos-ric-ho
     condition: import.onos-ric-ho.enabled
-    repository: https://sdrancharts.onosproject.org
+    repository: "@sdran"
     version: 0.0.8
   - name: onos-ric-mlb
     condition: import.onos-ric-mlb.enabled
-    repository: https://sdrancharts.onosproject.org
+    repository: "@sdran"
     version: 0.0.9
   - name: onos-topo
     condition: import.onos-topo.enabled
@@ -56,9 +56,9 @@ dependencies:
     version: 0.0.6
   - name: ran-simulator
     condition: import.ran-simulator.enabled
-    repository: https://sdrancharts.onosproject.org
+    repository: "@sdran"
     version: 0.0.7
   - name: onos-sdran-cli
     condition: import.onos-sdran-cli.enabled
-    repository: https://sdrancharts.onosproject.org
+    repository: "@sdran"
     version: 0.0.6


### PR DESCRIPTION
This PR updates the dependencies in the sd-ran chart. In order to `helm dependency update` the dependencies, the `sd-ran/Chart.yaml` is changed to use named repositories for sdran charts. When running `helm dependency update sd-ran`, the local Helm client must be configured with an `sdran` repository connecting to the secure private chart repo at `sdrancharts.onosproject.org`. This may or may not break the release build.