### PR TITLE
Build a combined chart directory when running local chart tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ version_check: # @HELP run the version checker on the charts
 
 test: # @HELP run the integration tests
 test: license_check version_check
-	helmit test ./test -c .
+	./build/bin/run-sd-ran-test
 
 publish: # @HELP publish version on github
 	./../build-tools/publish-version ${VERSION}

--- a/build/bin/run-sd-ran-test
+++ b/build/bin/run-sd-ran-test
@@ -1,0 +1,8 @@
+chart_dir=$(mktemp -d)
+
+cp -R ../onos-helm-charts/* ${chart_dir}
+cp -R ../sdran-helm-charts/* ${chart_dir}
+
+helmit test ./test -c ${chart_dir}
+
+# rm -rf ${chart_dir}


### PR DESCRIPTION
When running helmit against a context, the context must be a single directory tree that hols all of the charts. This PR creates a temporary chart tree and copies the onos-helm-charts and sdran-helm-charts charts into it before running tests.