### PR TITLE
Remove dependency manager init container from onos-ric-ho chart

### DIFF
--- a/onos-ric-ho/Chart.yaml
+++ b/onos-ric-ho/Chart.yaml
@@ -7,8 +7,8 @@ name: onos-ric-ho
 description: ONOS Radio Access Network Handover
 kubeVersion: ">=1.17.0"
 type: application
-version: 0.0.8
-appVersion: v0.6.13
+version: 0.0.9
+appVersion: v0.6.14
 keywords:
   - onos
   - sdn

--- a/onos-ric-ho/templates/deployment.yaml
+++ b/onos-ric-ho/templates/deployment.yaml
@@ -33,31 +33,6 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      initContainers:
-        - name: ric-ho-depcheck
-          image: {{ .Values.image.depCheck | quote }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
-          securityContext:
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: false
-            runAsUser: 0
-          env:
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: metadata.name
-            - name: NAMESPACE
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: metadata.namespace
-            - name: PATH
-              value: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/
-            - name: COMMAND
-              value: "echo done"
-            - name: DEPENDENCY_POD_JSON
-              value: '[{"labels": {"name": "onos-ric"}, "requireSameNode": false}]'
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -66,8 +41,8 @@ spec:
             - "-caPath=/etc/onos/certs/tls.cacrt"
             - "-keyPath=/etc/onos/certs/tls.key"
             - "-certPath=/etc/onos/certs/tls.crt"
-            - "-onosricaddr={{ .Values.onosricaddr }}"
-            - "-enableMetrics={{ .Values.enableMetrics }}"
+            - "-onosricaddr={{ index .Values "southbound.onos-ric.address" }}"
+            - "-enableMetrics={{ default .Values.metrics.enabled .Values.enableMetrics }}"
             - "-hystCqi={{ .Values.hoParams.hystCqi }}"
             - "-a3offsetCqi={{ .Values.hoParams.a3OffsetCqi }}"
             - "-timeToTrigger={{ .Values.hoParams.timeToTriggerMs }}"

--- a/onos-ric-ho/values.yaml
+++ b/onos-ric-ho/values.yaml
@@ -9,9 +9,8 @@
 replicaCount: 1
 
 image:
-  depCheck: quay.io/stackanetes/kubernetes-entrypoint:v0.3.1
   repository: onosproject/onos-ric-ho
-  tag: v0.6.13
+  tag: v0.6.14
   pullPolicy: IfNotPresent
   pullSecrets: []
 
@@ -19,15 +18,22 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: "onos-ric-ho"
 
-onosricaddr: "onos-ric:5150"
+# Deprecated: Use metrics.enabled instead
 enableMetrics: false
+
+metrics:
+  enabled: false
 
 hoParams:
   hystCqi: 0
   a3OffsetCqi: 0
   timeToTriggerMs: 0
 
-store: {}
+storage: {}
+
+southbound:
+  onos-ric:
+    address: "onos-ric:5150"
 
 service:
   # TODO: External NodePort service should be disabled by default


### PR DESCRIPTION
This PR removes the dependency checker init container from the onos-ric-ho deployment, relying instead on probes and retries.