### PR TITLE
Remove dependency manager init container from onos-ric-mlb chart

### DIFF
--- a/onos-ric-mlb/Chart.yaml
+++ b/onos-ric-mlb/Chart.yaml
@@ -7,8 +7,8 @@ name: onos-ric-mlb
 description: ONOS Radio Access Network Load Balancer
 kubeVersion: ">=1.17.0"
 type: application
-version: 0.0.9
-appVersion: v0.6.13
+version: 0.0.10
+appVersion: v0.6.14
 keywords:
   - onos
   - sdn

--- a/onos-ric-mlb/templates/deployment.yaml
+++ b/onos-ric-mlb/templates/deployment.yaml
@@ -33,31 +33,6 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      initContainers:
-        - name: ric-mlb-depcheck
-          image: {{ .Values.image.depCheck | quote }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
-          securityContext:
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: false
-            runAsUser: 0
-          env:
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: metadata.name
-            - name: NAMESPACE
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: metadata.namespace
-            - name: PATH
-              value: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/
-            - name: COMMAND
-              value: "echo done"
-            - name: DEPENDENCY_POD_JSON
-              value: '[{"labels": {"name": "onos-ric"}, "requireSameNode": false}]'
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -66,8 +41,8 @@ spec:
             - "-caPath=/etc/onos/certs/tls.cacrt"
             - "-keyPath=/etc/onos/certs/tls.key"
             - "-certPath=/etc/onos/certs/tls.crt"
-            - "-onosricaddr={{ .Values.onosricaddr }}"
-            - "-enableMetrics={{ .Values.enableMetrics }}"
+            - "-onosricaddr={{ index .Values "southbound.onos-ric.address" }}"
+            - "-enableMetrics={{ default .Values.metrics.enabled .Values.enableMetrics }}"
             - "-threshold={{ .Values.mlbParams.mlbThreshold }}"
             - "-period={{ .Values.mlbParams.mlbPeriod }}"
           livenessProbe:

--- a/onos-ric-mlb/values.yaml
+++ b/onos-ric-mlb/values.yaml
@@ -9,9 +9,8 @@
 replicaCount: 1
 
 image:
-  depCheck: quay.io/stackanetes/kubernetes-entrypoint:v0.3.1
   repository: onosproject/onos-ric-mlb
-  tag: v0.6.13
+  tag: v0.6.14
   pullPolicy: IfNotPresent
   pullSecrets: []
 
@@ -19,14 +18,21 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: "onos-ric-mlb"
 
-onosricaddr: "onos-ric:5150"
+# Deprecated: Use metrics.enabled instead
 enableMetrics: false
+
+metrics:
+  enabled: false
 
 mlbParams:
   mlbPeriod: 10000
   mlbThreshold: 1
 
-store: {}
+storage: {}
+
+southbound:
+  onos-ric:
+    address: "onos-ric:5150"
 
 service:
   # TODO: External NodePort service should be disabled by default


### PR DESCRIPTION
This PR removes the dependency checker init container from the onos-ric-mlb deployment, relying instead on probes and retries.