### PR TITLE
Switch onos-ric-ho probes to use TCP sockets

### DIFF
--- a/onos-ric-ho/Chart.yaml
+++ b/onos-ric-ho/Chart.yaml
@@ -7,7 +7,7 @@ name: onos-ric-ho
 description: ONOS Radio Access Network Handover
 kubeVersion: ">=1.17.0"
 type: application
-version: 0.0.9
+version: 0.0.10
 appVersion: v0.6.14
 keywords:
   - onos

--- a/onos-ric-ho/templates/deployment.yaml
+++ b/onos-ric-ho/templates/deployment.yaml
@@ -47,17 +47,16 @@ spec:
             - "-a3offsetCqi={{ .Values.hoParams.a3OffsetCqi }}"
             - "-timeToTrigger={{ .Values.hoParams.timeToTriggerMs }}"
           livenessProbe:
-            exec:
-              command:
-                - /bin/sh
-            initialDelaySeconds: 5
-            periodSeconds: 5
+            tcpSocket:
+              port: 5150
+            initialDelaySeconds: 30
+            periodSeconds: 10
           readinessProbe:
-            exec:
-              command:
-                - /bin/sh
-            initialDelaySeconds: 5
-            periodSeconds: 5
+            tcpSocket:
+              port: 5150
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 30
           volumeMounts:
             - name: secret
               mountPath: /etc/onos/certs


### PR DESCRIPTION
This PR switches the onos-ric-ho probes to probe the northbound API server using TCP sockets. The prior approach using `/bin/sh` was unreliable.