### PR TITLE
Switch onos-ric-mlb probes to use TCP sockets

### DIFF
--- a/onos-ric-mlb/Chart.yaml
+++ b/onos-ric-mlb/Chart.yaml
@@ -7,7 +7,7 @@ name: onos-ric-mlb
 description: ONOS Radio Access Network Load Balancer
 kubeVersion: ">=1.17.0"
 type: application
-version: 0.0.10
+version: 0.0.11
 appVersion: v0.6.14
 keywords:
   - onos

--- a/onos-ric-mlb/templates/deployment.yaml
+++ b/onos-ric-mlb/templates/deployment.yaml
@@ -46,17 +46,16 @@ spec:
             - "-threshold={{ .Values.mlbParams.mlbThreshold }}"
             - "-period={{ .Values.mlbParams.mlbPeriod }}"
           livenessProbe:
-            exec:
-              command:
-                - /bin/sh
-            initialDelaySeconds: 5
-            periodSeconds: 5
+            tcpSocket:
+              port: 5150
+            initialDelaySeconds: 30
+            periodSeconds: 10
           readinessProbe:
-            exec:
-              command:
-                - /bin/sh
-            initialDelaySeconds: 5
-            periodSeconds: 5
+            tcpSocket:
+              port: 5150
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 30
           volumeMounts:
             - name: secret
               mountPath: /etc/onos/certs


### PR DESCRIPTION
This PR switches the onos-ric-mlb probes to probe the northbound API server using TCP sockets. The prior approach using `/bin/sh` was unreliable.