### PR TITLE
Remove probes from onos-sdran-cli

### DIFF
--- a/onos-sdran-cli/Chart.yaml
+++ b/onos-sdran-cli/Chart.yaml
@@ -7,7 +7,7 @@ name: onos-sdran-cli
 description: ONOS Command Line Interface
 kubeVersion: ">=1.17.0"
 type: application
-version: 0.0.7
+version: 0.0.8
 appVersion: v0.6.11
 keywords:
   - onos

--- a/onos-sdran-cli/templates/deployment.yaml
+++ b/onos-sdran-cli/templates/deployment.yaml
@@ -45,18 +45,6 @@ spec:
               readOnly: true
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-          livenessProbe:
-            exec:
-              command:
-                - /bin/sh
-            initialDelaySeconds: 5
-            periodSeconds: 5
-          readinessProbe:
-            exec:
-              command:
-                - /bin/sh
-            initialDelaySeconds: 5
-            periodSeconds: 5
       volumes:
         - name: config
           configMap:


### PR DESCRIPTION
This PR removes readiness and liveness probes from the SD RAN CLI. The probes simply ran `/bin/sh` and seemed to accomplish little more than is accomplished by the Docker daemon which monitors containers. But `/bin/sh` probes with no command to return appear to be hanging in some environments.