### PR TITLE
Add startup probe to ran-simulator chart

### DIFF
--- a/ran-simulator/Chart.yaml
+++ b/ran-simulator/Chart.yaml
@@ -7,7 +7,7 @@ name: ran-simulator
 description: ONOS RAN Simulator
 kubeVersion: ">=1.15.0"
 type: application
-version: 0.0.9
+version: 0.0.10
 appVersion: v0.6.10
 keywords:
   - onos

--- a/ran-simulator/templates/deployment.yaml
+++ b/ran-simulator/templates/deployment.yaml
@@ -66,15 +66,20 @@ spec:
               containerPort: 40000
               protocol: TCP
             {{- end }}
-          livenessProbe:
+          startupProbe:
             tcpSocket:
               port: 5150
-            initialDelaySeconds: 15
-            periodSeconds: 20
+            periodSeconds: 5
+            failureThreshold: 60
           readinessProbe:
             tcpSocket:
               port: 5150
-            initialDelaySeconds: 5
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: 5150
+            initialDelaySeconds: 10
             periodSeconds: 10
           volumeMounts:
             - name: secret


### PR DESCRIPTION
Adds a startup probe to prevent restarts while waiting for dependencies during slow startup.