### PR TITLE
Add startup probe to onos-ric chart

### DIFF
--- a/onos-ric/Chart.yaml
+++ b/onos-ric/Chart.yaml
@@ -7,7 +7,7 @@ name: onos-ric
 description: ONOS Radio Access Network Intelligent Controller
 kubeVersion: ">=1.17.0"
 type: application
-version: 0.0.13
+version: 0.0.14
 appVersion: v0.6.14
 keywords:
   - onos

--- a/onos-ric/templates/statefulset.yaml
+++ b/onos-ric/templates/statefulset.yaml
@@ -92,15 +92,20 @@ spec:
               containerPort: 40000
               protocol: TCP
             {{- end }}
-          livenessProbe:
+          startupProbe:
             tcpSocket:
               port: 5150
-            initialDelaySeconds: 15
-            periodSeconds: 20
+            periodSeconds: 5
+            failureThreshold: 60
           readinessProbe:
             tcpSocket:
               port: 5150
-            initialDelaySeconds: 5
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: 5150
+            initialDelaySeconds: 10
             periodSeconds: 10
           volumeMounts:
             - name: config


### PR DESCRIPTION
Adds a startup probe to prevent restarts while waiting for dependencies during slow startup.