### PR TITLE
Add startup probe to onos-ric-ho chart

### DIFF
--- a/onos-ric-ho/Chart.yaml
+++ b/onos-ric-ho/Chart.yaml
@@ -7,7 +7,7 @@ name: onos-ric-ho
 description: ONOS Radio Access Network Handover
 kubeVersion: ">=1.17.0"
 type: application
-version: 0.0.11
+version: 0.0.12
 appVersion: v0.6.14
 keywords:
   - onos

--- a/onos-ric-ho/templates/deployment.yaml
+++ b/onos-ric-ho/templates/deployment.yaml
@@ -46,17 +46,21 @@ spec:
             - "-hystCqi={{ .Values.hoParams.hystCqi }}"
             - "-a3offsetCqi={{ .Values.hoParams.a3OffsetCqi }}"
             - "-timeToTrigger={{ .Values.hoParams.timeToTriggerMs }}"
-          livenessProbe:
+          startupProbe:
             tcpSocket:
               port: 5150
-            initialDelaySeconds: 30
-            periodSeconds: 10
+            periodSeconds: 5
+            failureThreshold: 60
           readinessProbe:
             tcpSocket:
               port: 5150
-            initialDelaySeconds: 30
+            initialDelaySeconds: 10
             periodSeconds: 10
-            failureThreshold: 30
+          livenessProbe:
+            tcpSocket:
+              port: 5150
+            initialDelaySeconds: 10
+            periodSeconds: 10
           volumeMounts:
             - name: secret
               mountPath: /etc/onos/certs


### PR DESCRIPTION
Adds a startup probe to prevent restarts while waiting for dependencies during slow startup.