### PR TITLE
Add startup probe to onos-ric-mlb chart

### DIFF
--- a/onos-ric-mlb/Chart.yaml
+++ b/onos-ric-mlb/Chart.yaml
@@ -7,7 +7,7 @@ name: onos-ric-mlb
 description: ONOS Radio Access Network Load Balancer
 kubeVersion: ">=1.17.0"
 type: application
-version: 0.0.12
+version: 0.0.13
 appVersion: v0.6.14
 keywords:
   - onos

--- a/onos-ric-mlb/templates/deployment.yaml
+++ b/onos-ric-mlb/templates/deployment.yaml
@@ -45,17 +45,21 @@ spec:
             - "-enableMetrics={{ default .Values.metrics.enabled .Values.enableMetrics }}"
             - "-threshold={{ .Values.mlbParams.mlbThreshold }}"
             - "-period={{ .Values.mlbParams.mlbPeriod }}"
-          livenessProbe:
+          startupProbe:
             tcpSocket:
               port: 5150
-            initialDelaySeconds: 30
-            periodSeconds: 10
+            periodSeconds: 5
+            failureThreshold: 60
           readinessProbe:
             tcpSocket:
               port: 5150
-            initialDelaySeconds: 30
+            initialDelaySeconds: 10
             periodSeconds: 10
-            failureThreshold: 30
+          livenessProbe:
+            tcpSocket:
+              port: 5150
+            initialDelaySeconds: 10
+            periodSeconds: 10
           volumeMounts:
             - name: secret
               mountPath: /etc/onos/certs


### PR DESCRIPTION
Adds a startup probe to prevent restarts while waiting for dependencies during slow startup.