### PR TITLE
Update sd-ran chart dependencies to use new probes

### DIFF
--- a/sd-ran/Chart.yaml
+++ b/sd-ran/Chart.yaml
@@ -24,23 +24,23 @@ dependencies:
     version: 1.3.20
   - name: onos-ric
     condition: import.onos-ric.enabled
-    repository: file://../onos-ric
+    repository: "@sdran"
     version: 0.0.15
   - name: onos-ric-ho
     condition: import.onos-ric-ho.enabled
-    repository: file://../onos-ric-ho
+    repository: "@sdran"
     version: 0.0.14
   - name: onos-ric-mlb
     condition: import.onos-ric-mlb.enabled
-    repository: file://../onos-ric-mlb
+    repository: "@sdran"
     version: 0.0.14
   - name: onos-topo
     condition: import.onos-topo.enabled
-    repository: file://../../onos-helm-charts/onos-topo
+    repository: https://charts.onosproject.org
     version: 0.0.13
   - name: onos-config
     condition: import.onos-config.enabled
-    repository: file://../../onos-helm-charts/onos-config
+    repository: https://charts.onosproject.org
     version: 0.0.14
   - name: onos-gui
     condition: import.onos-gui.enabled


### PR DESCRIPTION
This PR updates the sd-ran chart dependencies to use new probe configurations. Do not merge until probe changes have been merged and released.

https://github.com/onosproject/sdran-helm-charts/pull/64
https://github.com/onosproject/sdran-helm-charts/pull/65
https://github.com/onosproject/sdran-helm-charts/pull/66
https://github.com/onosproject/sdran-helm-charts/pull/67