### PR TITLE
Update sd-ran chart's onos-config dependency

### DIFF
--- a/sd-ran/Chart.yaml
+++ b/sd-ran/Chart.yaml
@@ -7,7 +7,7 @@ name: sd-ran
 description: Umbrella chart to deploy all ONOS-RIC and simulator
 kubeVersion: ">=1.17.0"
 type: application
-version: 0.0.35
+version: 0.0.36
 appVersion: v0.6.14
 keywords:
   - onos


### PR DESCRIPTION
Fixes race condition in loading model plugins in the onos-config service during startup.

Do not merge until the onos-config chart has been released and this PR has been tested with it.