### PR TITLE
Add publishNotReadyAddresses flag to onos-ric headless service

### DIFF
--- a/onos-ric/templates/service.yaml
+++ b/onos-ric/templates/service.yaml
@@ -39,6 +39,7 @@ metadata:
     {{- include "onos-ric.labels" . | nindent 4 }}
 spec:
   clusterIP: None
+  publishNotReadyAddresses: true
   selector:
     name: {{ template "onos-ric.fullname" . }}
     app: onos


### PR DESCRIPTION
This ensures pods can connect to each other before ready to initialize stores.