### PR TITLE
Fix order of arguments in sd-ran database image names

### DIFF
--- a/sd-ran/templates/database.yaml
+++ b/sd-ran/templates/database.yaml
@@ -38,7 +38,7 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
-  image: {{ default .Values.global.storage.consensus.image "atomix/raft-storage-node:v0.2.0" }}
+  image: {{ default "atomix/raft-storage-node:v0.3.0" .Values.global.storage.consensus.image }}
   imagePullPolicy: {{ .Values.global.storage.consensus.imagePullPolicy }}
   replicas: {{ .Values.global.storage.consensus.replicas }}
   partitionsPerCluster: {{ .Values.global.storage.consensus.partitionsPerCluster }}
@@ -53,7 +53,7 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
-  image: {{ default .Values.global.storage.consensus.image "atomix/cache-storage-node:v0.2.0" }}
+  image: {{ default "atomix/cache-storage-node:v0.3.0" .Values.global.storage.consensus.image }}
   imagePullPolicy: {{ .Values.global.storage.consensus.imagePullPolicy }}
 {{- else }}
 {{ fail ( printf "%s is not a valid storage type" .Values.global.storage.consensus.type ) }}


### PR DESCRIPTION
Incorrect argument order for the `default` function.