### PR TITLE
Set default storage image to empty string to inheret Atomix controller defaults

### DIFF
--- a/onos-e2sub/Chart.yaml
+++ b/onos-e2sub/Chart.yaml
@@ -7,7 +7,7 @@ name: onos-e2sub
 description: ONOS E2 Subscription Manager
 kubeVersion: ">=1.17.0"
 type: application
-version: 0.0.5
+version: 0.0.6
 appVersion: v0.6.4
 keywords:
   - onos

--- a/onos-e2sub/templates/database.yaml
+++ b/onos-e2sub/templates/database.yaml
@@ -38,7 +38,7 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
-  image: {{ default "atomix/raft-storage-node:v0.4.0" .Values.storage.consensus.image  }}
+  image: {{ .Values.storage.consensus.image | quote  }}
   imagePullPolicy: {{ .Values.storage.consensus.imagePullPolicy }}
   replicas: {{ .Values.storage.consensus.replicas }}
   partitionsPerCluster: {{ .Values.storage.consensus.partitionsPerCluster }}
@@ -53,7 +53,7 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
-  image: {{ default "atomix/cache-storage-node:v0.4.0" .Values.storage.consensus.image }}
+  image: {{ .Values.storage.consensus.image | quote }}
   imagePullPolicy: {{ .Values.storage.consensus.imagePullPolicy }}
 {{- else }}
 {{ fail ( printf "%s is not a valid storage type" .Values.storage.consensus.type ) }}


### PR DESCRIPTION
This PR removes the constant default image value for Atomix databases, relying instead on the controller defaults.