### PR TITLE
AETHER-1059: split post-install topo and config jobs

### DIFF
--- a/aether-roc-umbrella/Chart.yaml
+++ b/aether-roc-umbrella/Chart.yaml
@@ -7,7 +7,7 @@ name: aether-roc-umbrella
 description: Aether ROC Umbrella chart to deploy all Aether ROC
 kubeVersion: ">=1.17.0"
 type: application
-version: 0.0.26
+version: 0.0.27
 appVersion: v0.0.0
 keywords:
   - aether

--- a/aether-roc-umbrella/templates/post-install-config-job.yaml
+++ b/aether-roc-umbrella/templates/post-install-config-job.yaml
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: 2020-present Open Networking Foundation <info@opennetworking.org>
+#
+# SPDX-License-Identifier: LicenseRef-ONF-Member-1.0
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}-job-post-install-config"
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": post-install
+    "helm.sh/hook-weight": "5"
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+spec:
+  template:
+    metadata:
+      name: "{{ .Release.Name }}-job-post-install-config"
+      labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    spec:
+      restartPolicy: Never
+      containers:
+        {{- if index .Values "import" "onos-config" "enabled" }}
+          {{- if index .Values "onos-sdran-cli" "postInstall" "config" }}
+        - name: post-install-config-job
+          image: {{ index .Values "onos-sdran-cli" "image" "repository" }}:{{ index .Values "onos-sdran-cli" "image" "tag" }}
+          imagePullPolicy: {{ index .Values "onos-sdran-cli" "image" "pullPolicy" }}
+          command: ["/usr/local/bin/sdran"]
+          args:
+            - "config"
+            - "load"
+            - "proto"
+            {{- with index .Values "onos-sdran-cli" "postInstall" "config" }}
+            {{- range $filename := . }}
+            - {{ $filename }}
+            {{- end }}
+            {{- end }}
+          volumeMounts:
+            - name: config
+              mountPath: /home/onos
+              readOnly: true
+          {{- end }}
+        {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ .Release.Name }}-post

--- a/aether-roc-umbrella/templates/post-install-topo-job.yaml
+++ b/aether-roc-umbrella/templates/post-install-topo-job.yaml
@@ -5,7 +5,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "{{ .Release.Name }}-job-post-install"
+  name: "{{ .Release.Name }}-job-post-install-topo"
   labels:
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
@@ -20,7 +20,7 @@ metadata:
 spec:
   template:
     metadata:
-      name: "{{ .Release.Name }}-job-post-install"
+      name: "{{ .Release.Name }}-job-post-install-topo"
       labels:
         app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
         app.kubernetes.io/instance: {{ .Release.Name | quote }}
@@ -39,27 +39,6 @@ spec:
           - "load"
           - "yamlentities"
           - {{ index .Values "onos-sdran-cli" "postInstall" "topo" }}
-          volumeMounts:
-            - name: config
-              mountPath: /home/onos
-              readOnly: true
-          {{- end }}
-        {{- end }}
-        {{- if index .Values "import" "onos-config" "enabled" }}
-          {{- if index .Values "onos-sdran-cli" "postInstall" "config" }}
-        - name: post-install-config-job
-          image: {{ index .Values "onos-sdran-cli" "image" "repository" }}:{{ index .Values "onos-sdran-cli" "image" "tag" }}
-          imagePullPolicy: {{ index .Values "onos-sdran-cli" "image" "pullPolicy" }}
-          command: ["/usr/local/bin/sdran"]
-          args:
-            - "config"
-            - "load"
-            - "proto"
-            {{- with index .Values "onos-sdran-cli" "postInstall" "config" }}
-            {{- range $filename := . }}
-            - {{ $filename }}
-            {{- end }}
-            {{- end }}
           volumeMounts:
             - name: config
               mountPath: /home/onos


### PR DESCRIPTION
When combined, if the topo container fails and the config container succeeds, then K8s would retry both containers, and the config container would persistently fail with a "Key Violation" because it had already succeeded and created the objects.