### PR TITLE
Updates sd-ran chart to support NodePort in onos-e2t 1.0.1-rev1

### DIFF
--- a/sd-ran/Chart.yaml
+++ b/sd-ran/Chart.yaml
@@ -25,7 +25,7 @@ dependencies:
   - name: onos-e2t
     condition: import.onos-e2t.enabled
     repository: "@sdran"
-    version: 1.0.1
+    version: 1.0.1-rev1
   - name: onos-e2sub
     condition: import.onos-e2sub.enabled
     repository: "@sdran"


### PR DESCRIPTION
Sd-ran umbrella chart uses onos-e2t 1.0.1-rev1 revised chart
Enables NodePort backport in v1.0.0 in RiaB