### PR TITLE
aether-roc-umbrella: Releasing 0.1.0 using onos-operator

### DIFF
--- a/aether-roc-umbrella/Chart.yaml
+++ b/aether-roc-umbrella/Chart.yaml
@@ -7,7 +7,7 @@ name: aether-roc-umbrella
 description: Aether ROC Umbrella chart to deploy all Aether ROC
 kubeVersion: ">=1.17.0"
 type: application
-version: 0.0.31
+version: 0.0.32
 appVersion: v0.0.0
 keywords:
   - aether
@@ -21,18 +21,32 @@ dependencies:
     condition: import.onos-topo.enabled
     repository: https://charts.onosproject.org
     version: 1.0.4
+  - name: config-model-aether
+    condition: import.config-model-aether-2.0.0.enabled
+    repository: https://charts.onosproject.org
+    alias: aether-2-0-0
+    version: 2.0.1
+  - name: config-model-aether
+    condition: import.config-model-aether-1.0.0.enabled
+    repository: https://charts.onosproject.org
+    alias: aether-1-0-0
+    version: 1.0.0
+  - name: config-model-rbac
+    condition: import.config-model-rbac-1.0.0.enabled
+    repository: https://charts.onosproject.org
+    version: 1.0.0
   - name: onos-config
     condition: import.onos-config.enabled
     repository: https://charts.onosproject.org
-    version: 1.0.4
+    version: 1.1.10
   - name: onos-gui
     condition: import.onos-gui.enabled
     repository: https://charts.onosproject.org
-    version: 1.0.2
+    version: 1.0.4
   - name: onos-cli
     condition: import.onos-cli.enabled
     repository: https://charts.onosproject.org
-    version: 1.0.4
+    version: 1.0.5
   - name: aether-roc-api
     condition: import.aether-roc-api.enabled
     repository: "@sdran"

--- a/aether-roc-umbrella/values.yaml
+++ b/aether-roc-umbrella/values.yaml
@@ -26,6 +26,12 @@ global:
 import:
   onos-topo:
     enabled: true
+  config-model-aether-1.0.0:
+    enabled: false
+  config-model-aether-2.0.0:
+    enabled: true
+  config-model-rbac-1.0.0:
+    enabled: true
   onos-config:
     enabled: true
   onos-gui:
@@ -50,25 +56,7 @@ onos-config:
   storage:
     consensus:
       enabled: false
-  plugins:
-    - name: rbac
-      version: 1.0.0
-      image:
-        repository: onosproject/config-model-rbac-1.0.0
-        tag: v0.6.20
-        pullPolicy: IfNotPresent
-    - name: aether
-      version: 1.0.0
-      image:
-        repository: onosproject/config-model-aether-1.0.0
-        tag: v0.6.20
-        pullPolicy: IfNotPresent
-    - name: aether
-      version: 2.0.0
-      image:
-        repository: onosproject/config-model-aether-2.0.0
-        tag: v0.6.20
-        pullPolicy: IfNotPresent
+
 # ONOS-GUI
 onos-gui: {}
 


### PR DESCRIPTION
You must ensure that you load the `onos-controller` in to Kubernetes with
```bash
kubectl create -f https://raw.githubusercontent.com/onosproject/onos-operator/v0.4.1/deploy/onos-operator.yaml
```