### PR TITLE
Adds nodeSelector, tolerations and annotations to oai charts

### DIFF
--- a/oai-enb-cu/Chart.yaml
+++ b/oai-enb-cu/Chart.yaml
@@ -7,7 +7,7 @@ name: oai-enb-cu
 description: OAI CU Chart
 kubeVersion: ">=1.17.0"
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: v0.1.0
 keywords:
   - onos

--- a/oai-enb-cu/templates/statefulset-cu.yaml
+++ b/oai-enb-cu/templates/statefulset-cu.yaml
@@ -19,7 +19,19 @@ spec:
     metadata:
       labels:
 {{ tuple "oai-enb-cu" . | include "oai-enb-cu.metadata_labels" | indent 8 }}
+      {{- with .Values.annotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
+      {{- with index .Values "tolerations" }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with index .Values "nodeSelector" }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       hostNetwork: true
       initContainers:
       - name: oai-enb-cu-init

--- a/oai-enb-cu/values.yaml
+++ b/oai-enb-cu/values.yaml
@@ -14,6 +14,22 @@ images:
     oaicucp: docker.io/onosproject/oai-enb-cu:v0.1.0
   pullPolicy: IfNotPresent
 
+# Specify annotations (e.g., fluentbit/logging custom parser)
+# annotations:
+#   fluentbit.io/parser: oai
+
+# Specify nodeSelector to pin oai-enb-du to worker nodes oaienb only
+#
+# nodeSelector:
+#   node-role.test.org: oaienb
+
+# Override NoSchedule for oai-enb-du to be scheduled on oaienb worker nodes
+#
+# tolerations:
+#  - key: node-role.test.org
+#    value: oaienb
+#    effect: NoSchedule
+
 config:
   oai-enb-cu:
     enbID: 0xe00

--- a/oai-enb-du/Chart.yaml
+++ b/oai-enb-du/Chart.yaml
@@ -7,7 +7,7 @@ name: oai-enb-du
 description: OAI DU Chart
 kubeVersion: ">=1.17.0"
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: v0.1.0
 keywords:
   - onos

--- a/oai-enb-du/templates/statefulset-du.yaml
+++ b/oai-enb-du/templates/statefulset-du.yaml
@@ -19,7 +19,19 @@ spec:
     metadata:
       labels:
 {{ tuple "oai-enb-du" . | include "oai-enb-du.metadata_labels" | indent 8 }}
+      {{- with .Values.annotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
+      {{- with index .Values "tolerations" }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with index .Values "nodeSelector" }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       hostNetwork: true
       initContainers:
       - name: oai-enb-du-init

--- a/oai-enb-du/values.yaml
+++ b/oai-enb-du/values.yaml
@@ -14,6 +14,22 @@ images:
     oaidu: docker.io/onosproject/oai-enb-du:v0.1.0
   pullPolicy: IfNotPresent
 
+# Specify annotations (e.g., fluentbit/logging custom parser)
+# annotations:
+#   fluentbit.io/parser: oai
+
+# Specify nodeSelector to pin oai-enb-du to worker nodes oaienb only
+#
+# nodeSelector:
+#   node-role.test.org: oaienb
+
+# Override NoSchedule for oai-enb-du to be scheduled on oaienb worker nodes
+#
+# tolerations:
+#  - key: node-role.test.org
+#    value: oaienb
+#    effect: NoSchedule
+
 config:
   oai-enb-du:
     enableUSRP: false

--- a/oai-ue/Chart.yaml
+++ b/oai-ue/Chart.yaml
@@ -7,7 +7,7 @@ name: oai-ue
 description: OAI UE Chart
 kubeVersion: ">=1.17.0"
 type: application
-version: 0.1.2
+version: 0.1.3
 appVersion: v0.1.1
 keywords:
   - onos

--- a/oai-ue/templates/statefulset-ue.yaml
+++ b/oai-ue/templates/statefulset-ue.yaml
@@ -19,7 +19,19 @@ spec:
     metadata:
       labels:
 {{ tuple "oai-ue" . | include "oai-ue.metadata_labels" | indent 8 }}
+      {{- with .Values.annotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
+      {{- with index .Values "tolerations" }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with index .Values "nodeSelector" }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       hostNetwork: true
       initContainers:
       - name: oai-ue-init

--- a/oai-ue/values.yaml
+++ b/oai-ue/values.yaml
@@ -14,6 +14,22 @@ images:
     oaiue: docker.io/onosproject/oai-ue:v0.1.1
   pullPolicy: IfNotPresent
 
+# Specify annotations (e.g., fluentbit/logging custom parser)
+# annotations:
+#   fluentbit.io/parser: oai
+
+# Specify nodeSelector to pin oai-ue to worker nodes oaiue only
+#
+# nodeSelector:
+#   node-role.test.org: oaiue
+
+# Override NoSchedule for oai-ue to be scheduled on oaiue worker nodes
+#
+# tolerations:
+#  - key: node-role.test.org
+#    value: oaiue
+#    effect: NoSchedule
+
 config:
   oai-ue:
     enableUSRP: false


### PR DESCRIPTION
- By default nodeSelector, tolerations and annotations are not
defined in statefulset unless specified in values.yaml
- Enables oai charts to be used in terraform provisioning
tasks to specific (tainted/labelled) worker nodes (e.g., NUCs)