### PR TITLE
Adds nodeSelector, tolerations, annotations to oai-ue chart

### DIFF
--- a/oai-ue/Chart.yaml
+++ b/oai-ue/Chart.yaml
@@ -7,7 +7,7 @@ name: oai-ue
 description: OAI UE Chart
 kubeVersion: ">=1.17.0"
 type: application
-version: 0.1.2
+version: 0.1.3
 appVersion: v0.1.1
 keywords:
   - onos

--- a/oai-ue/templates/statefulset-ue.yaml
+++ b/oai-ue/templates/statefulset-ue.yaml
@@ -19,7 +19,19 @@ spec:
     metadata:
       labels:
 {{ tuple "oai-ue" . | include "oai-ue.metadata_labels" | indent 8 }}
+      {{- with .Values.annotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
+      {{- with index .Values "tolerations" }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with index .Values "nodeSelector" }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       hostNetwork: true
       initContainers:
       - name: oai-ue-init

--- a/oai-ue/values.yaml
+++ b/oai-ue/values.yaml
@@ -14,6 +14,22 @@ images:
     oaiue: docker.io/onosproject/oai-ue:v0.1.1
   pullPolicy: IfNotPresent
 
+# Specify annotations (e.g., fluentbit/logging custom parser)
+# annotations:
+#   fluentbit.io/parser: oai
+
+# Specify nodeSelector to pin oai-ue to worker nodes oaiue only
+#
+# nodeSelector:
+#   node-role.test.org: oaiue
+
+# Override NoSchedule for oai-ue to be scheduled on oaiue worker nodes
+#
+# tolerations:
+#  - key: node-role.test.org
+#    value: oaiue
+#    effect: NoSchedule
+
 config:
   oai-ue:
     enableUSRP: false


### PR DESCRIPTION
- By default nodeSelector, tolerations and annotations are not
defined in statefulset unless specified in values.yaml
- Enables oai charts to be used in terraform provisioning
tasks to specific (tainted/labelled) worker nodes (e.g., NUCs)