### PR TITLE
Adds nodeSelector, tolerations, annotations to oai-enb-du chart

### DIFF
--- a/oai-enb-du/Chart.yaml
+++ b/oai-enb-du/Chart.yaml
@@ -7,7 +7,7 @@ name: oai-enb-du
 description: OAI DU Chart
 kubeVersion: ">=1.17.0"
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: v0.1.0
 keywords:
   - onos

--- a/oai-enb-du/templates/statefulset-du.yaml
+++ b/oai-enb-du/templates/statefulset-du.yaml
@@ -19,7 +19,19 @@ spec:
     metadata:
       labels:
 {{ tuple "oai-enb-du" . | include "oai-enb-du.metadata_labels" | indent 8 }}
+      {{- with index .Values "annotations" }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
+      {{- with index .Values "tolerations" }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with index .Values "nodeSelector" }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       hostNetwork: true
       initContainers:
       - name: oai-enb-du-init

--- a/oai-enb-du/values.yaml
+++ b/oai-enb-du/values.yaml
@@ -14,6 +14,22 @@ images:
     oaidu: docker.io/onosproject/oai-enb-du:v0.1.0
   pullPolicy: IfNotPresent
 
+# Specify annotations (e.g., fluentbit/logging custom parser)
+# annotations:
+#   fluentbit.io/parser: oai
+
+# Specify nodeSelector to pin oai-enb-du to worker nodes oaienb only
+#
+# nodeSelector:
+#   node-role.test.org: oaienb
+
+# Override NoSchedule for oai-enb-du to be scheduled on oaienb worker nodes
+#
+# tolerations:
+#  - key: node-role.test.org
+#    value: oaienb
+#    effect: NoSchedule
+
 config:
   oai-enb-du:
     enableUSRP: false


### PR DESCRIPTION
By default nodeSelector, tolerations and annotations are not
defined in statefulset unless specified in values.yaml
Enables oai charts to be used in terraform provisioning
tasks to specific (tainted/labelled) worker nodes (e.g., NUCs)