### PR TITLE
aether-roc-umbrella: releasing 0.1.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ clean: # @HELP clean up temporary files.
 	rm -rf aether-roc-umbrella/charts aether-roc-umbrella/Chart.lock
 
 deps: # @HELP build dependencies for local charts.
+deps: clean
 	helm dep build sd-ran
 	helm dep build aether-roc-umbrella
 

--- a/aether-roc-umbrella/Chart.yaml
+++ b/aether-roc-umbrella/Chart.yaml
@@ -7,7 +7,7 @@ name: aether-roc-umbrella
 description: Aether ROC Umbrella chart to deploy all Aether ROC
 kubeVersion: ">=1.18.0"
 type: application
-version: 0.1.4
+version: 0.1.5
 appVersion: v0.0.0
 keywords:
   - aether
@@ -21,11 +21,6 @@ dependencies:
     condition: import.onos-topo.enabled
     repository: https://charts.onosproject.org
     version: 1.0.4
-  - name: config-model-aether
-    condition: onos-config.models.aether.v1.enabled
-    repository: https://charts.onosproject.org
-    version: 1.0.1
-    alias: config-model-aether-1-0-0
   - name: config-model-aether
     condition: onos-config.models.aether.v2.enabled
     repository: https://charts.onosproject.org


### PR DESCRIPTION
Currently the `helm package` tool can only handle one instance of `config-model-aether` - it might as well be 2.0.0