### PR TITLE
Charts for pci use case. ah-eson-test-server

### DIFF
--- a/ah-eson-test-server/Chart.yaml
+++ b/ah-eson-test-server/Chart.yaml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2020-present Open Networking Foundation <info@opennetworking.org>
+#
+# SPDX-License-Identifier: LicenseRef-ONF-Member-1.0
+
+apiVersion: v2
+name: ah-eson-test-server
+description: FB ah-eson-test-server
+kubeVersion: ">=1.17.0"
+type: application
+version: 0.0.1
+appVersion: 0.0.1
+keywords:
+  - onos
+  - sdn
+  - ric
+  - fb
+home: https://connectivity.fb.com/
+maintainers:
+  - name: Maveric Team
+    email: fbc_maveric@fb.com

--- a/ah-eson-test-server/templates/_helpers.tpl
+++ b/ah-eson-test-server/templates/_helpers.tpl
@@ -1,0 +1,52 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "ah-eson-test-server.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "ah-eson-test-server.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "ah-eson-test-server.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "ah-eson-test-server.labels" -}}
+helm.sh/chart: {{ include "ah-eson-test-server.chart" . }}
+{{ include "ah-eson-test-server.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "ah-eson-test-server.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "ah-eson-test-server.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/ah-eson-test-server/templates/configmap.yaml
+++ b/ah-eson-test-server/templates/configmap.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2020-present Open Networking Foundation <info@opennetworking.org>
+#
+# SPDX-License-Identifier: LicenseRef-ONF-Member-1.0
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "ah-eson-test-server.fullname" . }}-config
+  labels:
+    app: {{ template "ah-eson-test-server.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"

--- a/ah-eson-test-server/templates/deployment.yaml
+++ b/ah-eson-test-server/templates/deployment.yaml
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: 2020-present Open Networking Foundation <info@opennetworking.org>
+#
+# SPDX-License-Identifier: LicenseRef-ONF-Member-1.0
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "ah-eson-test-server.fullname" . }}
+  labels:
+    {{- include "ah-eson-test-server.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      name: {{ template "ah-eson-test-server.fullname" . }}
+      app: ah-eson-test-server
+      type: ah-eson-test-server
+      resource: {{ template "ah-eson-test-server.fullname" . }}
+      {{- include "ah-eson-test-server.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        name: {{ template "ah-eson-test-server.fullname" . }}
+        app: ah-eson-test-server
+        type: ah-eson-test-server
+        resource: {{ template "ah-eson-test-server.fullname" . }}
+        {{- include "ah-eson-test-server.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: ah-eson-test-server
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          tty: true
+          command: {{ .Values.command }}
+          args:
+            - "--port=[::]:{{ .Values.servicePort }}"
+            - "--service_port={{ .Values.servicePort }}"
+            - '--service_hostname={{ template "ah-eson-test-server.fullname" . }}'
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          ports:
+            - name: tcp
+              containerPort: {{ .Values.servicePort }}
+          startupProbe:
+            tcpSocket:
+              port: {{ .Values.servicePort }}
+            periodSeconds: 5
+            failureThreshold: 60
+          readinessProbe:
+            tcpSocket:
+              port: {{ .Values.servicePort }}
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: {{ .Values.servicePort }}
+            initialDelaySeconds: 10
+            periodSeconds: 10
+
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/ah-eson-test-server/templates/secret.yaml
+++ b/ah-eson-test-server/templates/secret.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: 2020-present Open Networking Foundation <info@opennetworking.org>
+#
+# SPDX-License-Identifier: LicenseRef-ONF-Member-1.0
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "ah-eson-test-server.fullname" . }}-secret
+  labels:
+     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+     release: "{{ .Release.Name }}"
+     heritage: "{{ .Release.Service }}"
+data:
+  {{ $root := . }}
+  {{ range $path, $bytes := .Files.Glob "files/certs/tls.*" }}
+  {{ base $path }}: '{{ $root.Files.Get $path | b64enc }}'
+  {{ end }}
+type: Opaque

--- a/ah-eson-test-server/templates/service.yaml
+++ b/ah-eson-test-server/templates/service.yaml
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: 2020-present Open Networking Foundation <info@opennetworking.org>
+#
+# SPDX-License-Identifier: LicenseRef-ONF-Member-1.0
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "ah-eson-test-server.fullname" . }}
+  labels:
+    app: {{ template "ah-eson-test-server.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+    {{- include "ah-eson-test-server.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  selector:
+    name: {{ template "ah-eson-test-server.fullname" . }}
+    app: ah-eson-test-server
+    type: ah-eson-test-server
+    resource: {{ template "ah-eson-test-server.fullname" . }}
+    {{- include "ah-eson-test-server.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: eson
+      port: {{ .Values.servicePort }}

--- a/ah-eson-test-server/templates/serviceaccount.yaml
+++ b/ah-eson-test-server/templates/serviceaccount.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: 2020-present Open Networking Foundation <info@opennetworking.org>
+#
+# SPDX-License-Identifier: LicenseRef-ONF-Member-1.0
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ah-eson-test-server
+  namespace: {{ .Release.Namespace }}

--- a/ah-eson-test-server/values.yaml
+++ b/ah-eson-test-server/values.yaml
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: 2020-present Open Networking Foundation <info@opennetworking.org>
+#
+# SPDX-License-Identifier: LicenseRef-ONF-Member-1.0
+# Default values for ah-eson-test-server.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: onosproject/ah-eson-test-server
+  tag: 0.0.1
+  pullPolicy: IfNotPresent
+  pullSecrets: []
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: "ah-eson-test-server"
+
+command: ["./server.py"]
+servicePort: 51050
+
+storage: {}
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
chart for ah-eson-test-server, listens for connection from fb-ah-xapp