### PR TITLE
Updates oai-enb-du with radio value params for usrp

### DIFF
--- a/oai-enb-du/Chart.yaml
+++ b/oai-enb-du/Chart.yaml
@@ -7,7 +7,7 @@ name: oai-enb-du
 description: OAI DU Chart
 kubeVersion: ">=1.17.0"
 type: application
-version: 0.1.4
+version: 0.1.5
 appVersion: v0.1.4
 keywords:
   - onos

--- a/oai-enb-du/templates/_du_conf_usrp.tpl
+++ b/oai-enb-du/templates/_du_conf_usrp.tpl
@@ -2,6 +2,11 @@
 #
 # SPDX-License-Identifier: LicenseRef-ONF-Member-1.0
 
+{{- $rxgain := index .Values "config" "oai-enb-du" "radio" "rx_gain" }}
+{{- $txgain := index .Values "config" "oai-enb-du" "radio" "tx_gain" }}
+{{- $maxrxgain := index .Values "config" "oai-enb-du" "radio" "max_rxgain" }}
+{{- $maxpdschReferenceSignalPower := index .Values "config" "oai-enb-du" "radio" "max_pdschReferenceSignalPower" }}
+
 Active_eNBs = ( "eNB-Eurecom-DU");
 # Asn1_verbosity, choice in: none, info, annoying
 Asn1_verbosity = "none";
@@ -40,8 +45,8 @@ eNBs =
         nb_antenna_ports        = 1;
         nb_antennas_tx          = 1;
         nb_antennas_rx          = 1;
-        tx_gain                 = 90;
-        rx_gain                 = 125;
+        tx_gain                 = {{ $txgain }};
+        rx_gain                 = {{ $rxgain }};
 
         pucch_deltaF_Format1    = "deltaF2";
         pucch_deltaF_Format1b   = "deltaF3";
@@ -92,8 +97,8 @@ RUs = (
     att_tx                        = 10;
     att_rx                        = 10;
     bands                         = [7];
-    max_pdschReferenceSignalPower = -25;
-    max_rxgain                    = 125;
+    max_pdschReferenceSignalPower = {{ $maxpdschReferenceSignalPower }};
+    max_rxgain                    = {{ $maxrxgain }};
     eNB_instances                 = [0];
   }
 );

--- a/oai-enb-du/values.yaml
+++ b/oai-enb-du/values.yaml
@@ -36,6 +36,11 @@ config:
       level: "info"
       verbosity: "medium"
     enableUSRP: false
+    radio:
+      max_rxgain: 125
+      max_pdschReferenceSignalPower: -25
+      rx_gain: 125
+      tx_gain: 90
     mode: nfapi #or local_L1 for USRP and BasicSim
     networks:
       f1:


### PR DESCRIPTION
- Includes tx_gain, rx_gain, max_rxgain, and
max_pdschReferenceSignalPower