### PR TITLE
aether-roc-umbrella: adding sdcore-test-dummy

### DIFF
--- a/aether-roc-umbrella/Chart.yaml
+++ b/aether-roc-umbrella/Chart.yaml
@@ -7,7 +7,7 @@ name: aether-roc-umbrella
 description: Aether ROC Umbrella chart to deploy all Aether ROC
 kubeVersion: ">=1.18.0"
 type: application
-version: 1.0.3
+version: 1.0.4
 appVersion: v0.0.0
 keywords:
   - aether
@@ -60,3 +60,8 @@ dependencies:
     condition: import.sdcore-adapter.enabled
     repository: "@sdran"
     version: 0.0.16
+  - name: nginx
+    alias: sdcore-test-dummy
+    condition: import.sdcore-test-dummy.enabled
+    repository: "@bitnami"
+    version: 8.9.0

--- a/aether-roc-umbrella/README.md
+++ b/aether-roc-umbrella/README.md
@@ -1,15 +1,62 @@
 ## Aether ROC Umbrella chart
 
-Provides a [Helm] chart for deploying aether-portal, aether-roc, onos-topo, onos-config, onos-gui to [Kubernetes].
-See the [documentation] for more info.
+First add repos to your Helm client
+```
+stable       	https://charts.helm.sh/stable                        
+cord         	https://charts.opencord.org                          
+atomix       	https://charts.atomix.io                             
+onosproject  	https://charts.onosproject.org                       
+sdran        	https://sdrancharts.onosproject.org                  
+aether       	https://charts.aetherproject.org                     
+cetic        	https://cetic.github.io/helm-charts                  
+bitnami      	https://charts.bitnami.com/bitnami
+```
 
-To deploy with Authentication enabled:
-First deploy the [dex-ldap-umbrella](https://github.com/onosproject/onos-helm-charts/tree/master/dex-ldap-umbrella)
+Provides a [Helm] chart for deploying
+
+* aether-roc-gui, 
+* aether-roc-api 
+* onos-topo
+* onos-config 
+* onos-gui
+
+to [Kubernetes].
+> See the [documentation] for more info.
+
+## Config models
+The Aether ROC Umbrella chart controls the Config Model Plugins that are enabled in `onos-config`
+Currently 4 versions of the `Aether` model are loaded:
+
+* aether-1.0.0
+* aether-2.0.0
+* aether-2.1.0
+* aether-2.2.0
+
+## Deploy with Authentication enabled
+
+1) install the helm Repo https://cetic.github.io/helm-charts
+2) deploy the [dex-ldap-umbrella](https://github.com/onosproject/onos-helm-charts/tree/master/dex-ldap-umbrella)
 
 Then run:
 ```bash
 hm install aether-roc-umbrella ./aether-roc-umbrella --set onos-config.openidc.issuer=http://dex-ldap-umbrella:32000 --set aether-roc-gui.openidc.issuer=http://dex-ldap-umbrella:32000
 ```
+
+## sdcore-test-dummy 
+The chart includes the `sdcore-test-dummy` container for testing the `sdcore-adapter`
+
+> this may be disabled in the chart with `--set import.sdcore-test-dummy.enabled=false`
+
+This runs in the cluster at http://aether-roc-umbrella-sdcore-test-dummy (port 80)
+
+This is a simple nginx server that has been configured to accept POST requests and 
+log their contents. Use `kubectl -n <namespace> logs --follow <pod identifier>` to
+see the POST request contents.
+
+In a configuration of a `connectivity-service` the following values should be set:
+* hss-endpoint http://aether-roc-umbrella-sdcore-test-dummy/v1/config/imsis
+* spgwc-endpoint http://aether-roc-umbrella-sdcore-test-dummy/v1/config
+* pcrf-endpoint http://aether-roc-umbrella-sdcore-test-dummy/v1/config policies
 
 [Kubernetes]: https://kubernetes.io/
 [Helm]: https://helm.sh/

--- a/aether-roc-umbrella/values.yaml
+++ b/aether-roc-umbrella/values.yaml
@@ -38,6 +38,8 @@ import:
     enabled: true
   sdcore-adapter:
     enabled: true
+  sdcore-test-dummy:
+    enabled: true
 
 # ONOS-TOPO
 onos-topo:
@@ -79,3 +81,38 @@ sdcore-adapter:
   nameOverride: sdcore-adapter
   fullnameOverride: sdcore-adapter
   prometheusEnabled: false
+
+# SD-Core Test Dummy
+# proxy_pass has to be added or nginx will not log the $request_body
+sdcore-test-dummy:
+  serviceType: NodePort
+  serverBlock: |-
+    log_format client '$remote_addr - $remote_user $request_time $upstream_response_time '
+                      '[$time_local] "$request" $status $body_bytes_sent $request_body "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    server {
+      listen 0.0.0.0:8080;
+      default_type application/json;
+      access_log /opt/bitnami/nginx/logs/access.log client;
+
+      # You can provide a special subPath or the root
+      location = /v1/config {
+        root /;
+        proxy_pass http://127.0.0.1:8080/post_dummy;
+      }
+      location = /v1/config/policies {
+        root /;
+        proxy_pass http://127.0.0.1:8080/post_dummy;
+      }
+      location = /v1/config/imsis {
+        root /;
+        proxy_pass http://127.0.0.1:8080/post_dummy;
+      }
+      location = /post_dummy {
+        # turn off logging here to avoid double logging
+        access_log off;
+        return 200;
+      }
+      error_page  405     =200 $uri;
+    }


### PR DESCRIPTION
Adds an `nginx` server available on http://aether-roc-umbrella-sdcore-test-dummy (port 80)

Requires the **bitnami** Charts to be installed
```helm repo add bitnami https://charts.bitnami.com/bitnami```

In a configuration of a `connectivity-service` the following values should be set:
* hss-endpoint http://aether-roc-umbrella-sdcore-test-dummy/v1/config/imsis
* spgwc-endpoint http://aether-roc-umbrella-sdcore-test-dummy/v1/config
* pcrf-endpoint http://aether-roc-umbrella-sdcore-test-dummy/v1/config policies
