### PR TITLE
Update onos-config dependency to support Atomix v2beta1 API in sd-ran chart

### DIFF
--- a/sd-ran/Chart.yaml
+++ b/sd-ran/Chart.yaml
@@ -7,7 +7,7 @@ name: sd-ran
 description: Umbrella chart to deploy all ONOS-RIC and simulator
 kubeVersion: ">=1.17.0"
 type: application
-version: 1.1.25
+version: 1.1.26
 appVersion: v1.1.2
 keywords:
   - onos
@@ -25,7 +25,7 @@ dependencies:
   - name: onos-e2t
     condition: import.onos-e2t.enabled
     repository: "@sdran"
-    version: 1.0.27
+    version: 1.0.28
   - name: onos-e2sub
     condition: import.onos-e2sub.enabled
     repository: "@sdran"
@@ -37,11 +37,11 @@ dependencies:
   - name: onos-topo
     condition: import.onos-topo.enabled
     repository: https://charts.onosproject.org
-    version: 1.0.10
+    version: 1.0.11
   - name: onos-config
     condition: import.onos-config.enabled
     repository: https://charts.onosproject.org
-    version: 1.1.17
+    version: 1.1.23
   - name: config-model-ric
     condition: onos-config.models.ric.v1.enabled
     repository: "@sdran"

--- a/sd-ran/values.yaml
+++ b/sd-ran/values.yaml
@@ -139,6 +139,10 @@ onos-topo:
       enabled: false
 
 onos-config:
+  store:
+    consensus:
+      enabled: false
+  # Deprecated: use 'store' instead
   storage:
     controller: ""
     consensus:


### PR DESCRIPTION
Update the sd-ran chart to ensure components share a single Atomix v2beta1 consensus store.