### PR TITLE
Updates oai-ue with MSIN values with 9 digits and zero padding

### DIFF
--- a/oai-ue/Chart.yaml
+++ b/oai-ue/Chart.yaml
@@ -7,7 +7,7 @@ name: oai-ue
 description: OAI UE Chart
 kubeVersion: ">=1.17.0"
 type: application
-version: 0.1.5
+version: 0.1.6
 appVersion: v0.1.4
 keywords:
   - onos

--- a/oai-ue/templates/_ue_sim_conf.tpl
+++ b/oai-ue/templates/_ue_sim_conf.tpl
@@ -9,6 +9,8 @@
 {{- $startIMEI := index .Values "config" "oai-ue" "device" "imei" }}
 {{- $startMSIN := index .Values "config" "oai-ue" "sim" "msinStart" }}
 {{- $startMSISDN := index .Values "config" "oai-ue" "sim" "msisdnStart" }}
+{{- $startMSINlen := index .Values "config" "oai-ue" "sim" "msinStart" | toString | len | int }}
+{{- $MSINlensub := sub 10 $startMSINlen | int }}
 
 PLMN: {
     PLMN0: {
@@ -27,7 +29,7 @@ UE{{ $i }}: {
         PIN={{ index $.Values "config" "oai-ue" "device" "pin" | quote }};
     };
     SIM: {
-        MSIN={{ add $startMSIN $i | quote }};
+        MSIN={{ add $startMSIN $i | printf "%010d" | substr $MSINlensub 10 | quote }};
         USIM_API_K={{ index $.Values "config" "oai-ue" "sim" "apiKey" | quote }};
         OPC={{ index $.Values "config" "oai-ue" "sim" "opc" | quote }};
         MSISDN={{ add $startMSISDN $i | quote }};


### PR DESCRIPTION
In DT the msinStart value is set to 0000000001.
The oai-ue helm chart considers that a binary, and change that to
1 (removes the left zeros).
In the file _ue_sim_conf.tpl , the line
MSIN={{ add $startMSIN $i | quote }};  makes MSIN equals to 1
(instead of 0000000001).
That creates an error in the init container and forbids its
initialization.
The solution is to add zeros as a padding in a printf string,
but another issue is that MSIN in Germany has 10 digits.
The solution also makes a padding to 9 digits MSIN.