### PR TITLE
aether-roc-umbrella: releasing 1.1.2 to control post install

### DIFF
--- a/aether-roc-umbrella/Chart.yaml
+++ b/aether-roc-umbrella/Chart.yaml
@@ -7,7 +7,7 @@ name: aether-roc-umbrella
 description: Aether ROC Umbrella chart to deploy all Aether ROC
 kubeVersion: ">=1.18.0"
 type: application
-version: 1.1.1
+version: 1.1.2
 appVersion: v0.0.0
 keywords:
   - aether

--- a/aether-roc-umbrella/templates/post-install-topo-job.yaml
+++ b/aether-roc-umbrella/templates/post-install-topo-job.yaml
@@ -1,7 +1,8 @@
 # SPDX-FileCopyrightText: 2020-present Open Networking Foundation <info@opennetworking.org>
 #
 # SPDX-License-Identifier: LicenseRef-ONF-Member-1.0
-
+{{- if index .Values "onos-cli" "postInstall"}}
+{{- if index .Values "onos-cli" "postInstall" "topo"}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -28,8 +29,6 @@ spec:
     spec:
       restartPolicy: Never
       containers:
-        {{- if index .Values "import" "onos-topo" "enabled" }}
-          {{- if index .Values "onos-cli" "postInstall" "topo"}}
         - name: post-install-topo-new-job
           image: {{ index .Values "onos-cli" "image" "repository" }}:{{ index .Values "onos-cli" "image" "tag" }}
           imagePullPolicy: {{ index .Values "onos-cli" "image" "pullPolicy" }}
@@ -42,9 +41,9 @@ spec:
             - name: config
               mountPath: /home/onos
               readOnly: true
-          {{- end }}
-        {{- end }}
       volumes:
         - name: config
           configMap:
             name: {{ .Release.Name }}-post
+      {{- end }}
+  {{- end }}

--- a/aether-roc-umbrella/values.yaml
+++ b/aether-roc-umbrella/values.yaml
@@ -97,8 +97,8 @@ onos-gui: {}
 # ONOS-CLI
 onos-cli:
   postInstall:
-    placeholder: true
     topo: spgw-1-topo-entities.json
+# Use "--set onos-cli.postInstall=null" to disable
 
 # Aether ROC API
 aether-roc-api: {}


### PR DESCRIPTION
Changed the override for post-install

Now it can be disabled with 
```
--set onos-cli.postInstall=null
```