### PR TITLE
aether-roc-umbrella: releasing 1.1.3 for ROC GUI update

### DIFF
--- a/aether-roc-umbrella/Chart.yaml
+++ b/aether-roc-umbrella/Chart.yaml
@@ -7,7 +7,7 @@ name: aether-roc-umbrella
 description: Aether ROC Umbrella chart to deploy all Aether ROC
 kubeVersion: ">=1.18.0"
 type: application
-version: 1.1.2
+version: 1.1.3
 appVersion: v0.0.0
 keywords:
   - aether
@@ -52,19 +52,19 @@ dependencies:
   - name: onos-cli
     condition: import.onos-cli.enabled
     repository: https://charts.onosproject.org
-    version: 1.0.12
+    version: 1.0.13
   - name: aether-roc-api
     condition: import.aether-roc-api.enabled
     repository: "@sdran"
-    version: 1.0.2
+    version: 1.0.3
   - name: aether-roc-gui
     condition: import.aether-roc-gui.enabled
     repository: "@sdran"
-    version: 1.0.2
+    version: 1.0.3
   - name: sdcore-adapter
     condition: import.sdcore-adapter.enabled
     repository: "@sdran"
-    version: 0.0.17
+    version: 0.0.18
   - name: nginx
     alias: sdcore-test-dummy
     condition: import.sdcore-test-dummy.enabled


### PR DESCRIPTION
Includes Aether ROC GUI `v0.6.22` which includes

- [AETHER-1567](https://jira.opennetworking.org/browse/AETHER-1567) - when a change is in the basket, this should be applied to form and list views
- [AETHER-1706](https://jira.opennetworking.org/browse/AETHER-1706) - missing id field on pages for creating new models
- [AETHER-1721](https://jira.opennetworking.org/browse/AETHER-1721) - Signing out no longer deletes items stored in basket
- [AETHER-1813](https://jira.opennetworking.org/browse/AETHER-1813) - Add IDs to components to help TAM test them
