### PR TITLE
Update aether-roc-umbrella chart to use Atomix v2beta1 stores

### DIFF
--- a/aether-roc-umbrella/Chart.yaml
+++ b/aether-roc-umbrella/Chart.yaml
@@ -7,7 +7,7 @@ name: aether-roc-umbrella
 description: Aether ROC Umbrella chart to deploy all Aether ROC
 kubeVersion: ">=1.18.0"
 type: application
-version: 1.2.4
+version: 1.2.5
 appVersion: v0.0.0
 keywords:
   - aether
@@ -20,7 +20,7 @@ dependencies:
   - name: onos-topo
     condition: import.onos-topo.enabled
     repository: https://charts.onosproject.org
-    version: 1.0.11
+    version: 1.0.12
   - name: config-model-aether
     condition: onos-config.models.aether.v2.enabled
     repository: "@sdran"
@@ -39,7 +39,7 @@ dependencies:
   - name: onos-config
     condition: import.onos-config.enabled
     repository: https://charts.onosproject.org
-    version: 1.1.25
+    version: 1.1.26
   - name: onos-gui
     condition: import.onos-gui.enabled
     repository: https://charts.onosproject.org

--- a/aether-roc-umbrella/templates/_helpers.tpl
+++ b/aether-roc-umbrella/templates/_helpers.tpl
@@ -55,11 +55,15 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 global consensus image name
 */}}
 {{- define "global.store.consensus.imagename" -}}
+{{- if .Values.global.store.consensus.image.tag -}}
 {{- if .Values.global.store.consensus.image.registry -}}
 {{- printf "%s/" .Values.global.store.consensus.image.registry -}}
 {{- end -}}
 {{- printf "%s:" .Values.global.store.consensus.image.repository -}}
 {{- .Values.global.store.consensus.image.tag -}}
+{{- else -}}
+""
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/aether-roc-umbrella/templates/store.yaml
+++ b/aether-roc-umbrella/templates/store.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-ONF-Member-1.0
 
-{{- if .Values.global.storage.consensus.enabled }}
+{{- if .Values.global.store.consensus.enabled }}
 apiVersion: atomix.io/v2beta1
 kind: Store
 metadata:

--- a/aether-roc-umbrella/values.yaml
+++ b/aether-roc-umbrella/values.yaml
@@ -19,7 +19,7 @@ global:
       image:
         registry: ""
         repository: atomix/atomix-raft-storage-node
-        tag: v0.6.6
+        tag: ""
         pullPolicy: IfNotPresent
         pullSecrets: []
       clusters: 1
@@ -32,7 +32,7 @@ global:
   storage:
     controller: "atomix-controller.kube-system.svc.cluster.local:5679"
     consensus:
-      enabled: true
+      enabled: false
       name: ""
       type: raft
       image: ""


### PR DESCRIPTION
Fixes some minor bugs in the chart. Also disables Atomix v1beta1 stores to reduce the load on the cluster. Uses the latest onos-topo and onos-config charts for Atomix v2beta1 API.