### PR TITLE
aether-roc-gui: releasing 3.0.3 for v0.7.2

### DIFF
--- a/aether-roc-gui/Chart.yaml
+++ b/aether-roc-gui/Chart.yaml
@@ -7,7 +7,7 @@ name: aether-roc-gui
 description: Aether ROC Graphical User Interface
 kubeVersion: ">=1.15.0"
 type: application
-version: 3.0.2
+version: 3.0.3
 appVersion: 3.0.0
 keywords:
   - aether

--- a/aether-roc-gui/values.yaml
+++ b/aether-roc-gui/values.yaml
@@ -10,7 +10,7 @@ replicaCount: 1
 
 image:
   repository: onosproject/aether-roc-gui
-  tag: v0.7.1
+  tag: v0.7.2
   pullPolicy: IfNotPresent
   pullSecrets: []
 
@@ -65,8 +65,14 @@ aetherservices:
     streamTimeout: 3600
 
 grafana:
-  proxyEnabled: true
+  proxyEnabled: false
   service: grafana
+  protocol: http
+  port: 80
+
+prometheus:
+  proxyEnabled: false
+  service: prometheus
   protocol: http
   port: 80
 
@@ -81,7 +87,21 @@ Nginx:
           location /grafana/ {
               proxy_pass {{ .Values.grafana.protocol }}://{{ .Values.grafana.service }}:{{ .Values.grafana.port }}/;
               proxy_http_version 1.1;
+              proxy_redirect off;
+              proxy_set_header Upgrade $http_upgrade;
+              proxy_set_header Connection "Upgrade";
+              proxy_set_header X-Real-IP $remote_addr;
+              proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+              proxy_set_header Host $http_host;
+              proxy_set_header X-NginX-Proxy true;
               proxy_hide_header 'X-Frame-Options';
+              add_header X-Frame-Options SAMEORIGIN;
+          }{{end}}
+          {{- if .Values.prometheus.proxyEnabled }}
+          location /prometheus/ {
+              proxy_pass {{ .Values.prometheus.protocol }}://{{ .Values.prometheus.service }}:{{ .Values.prometheus.port }}/;
+              proxy_http_version 1.1;
+              proxy_set_header Upgrade $http_upgrade;
               add_header X-Frame-Options SAMEORIGIN;
           }{{end}}
           location / {


### PR DESCRIPTION
Also

- added a Prometheus proxy-pass
- Fixed Grafana proxy-pass to allow Web Sockets