### PR TITLE
aether-roc-umbrella: adding LDAP auth for Grafana

### DIFF
--- a/aether-roc-umbrella/Chart.yaml
+++ b/aether-roc-umbrella/Chart.yaml
@@ -7,7 +7,7 @@ name: aether-roc-umbrella
 description: Aether ROC Umbrella chart to deploy all Aether ROC
 kubeVersion: ">=1.18.0"
 type: application
-version: 1.2.14
+version: 1.2.15
 appVersion: v0.0.0
 keywords:
   - aether

--- a/aether-roc-umbrella/values.yaml
+++ b/aether-roc-umbrella/values.yaml
@@ -123,6 +123,9 @@ grafana:
       org_name: Main Org.
       org_role: Viewer
       hide_version: true
+    auth.ldap:
+      enabled: true
+      config_file: /etc/grafana/ldap.toml
   datasources:
     datasources.yaml:
       apiVersion: 1
@@ -146,6 +149,46 @@ grafana:
           path: /var/lib/grafana/dashboards/default
   dashboardsConfigMaps:
     default: aether-roc-umbrella-dashboards
+  ldap:
+    enabled: true
+    config: |-
+      verbose_logging = true
+      [[servers]]
+      host = "dex-ldap-umbrella-openldap"
+      port = 389
+      use_ssl = false
+      start_tls = false
+      ssl_skip_verify = false
+      bind_dn = "cn=admin,dc=opennetworking,dc=org"
+      bind_password = 'password'
+      search_filter = "(uid=%s)"
+      search_base_dns = ["cn=users,dc=opennetworking,dc=org"]
+
+      group_search_filter = "(&(objectClass=posixGroup)(memberUid=%s))"
+      group_search_base_dns = ["cn=groups,dc=opennetworking,dc=org"]
+      group_search_filter_user_attribute = "uid"
+
+      [servers.attributes]
+      member_of = "memberOf"
+      email = "mail"
+      first_name = "sn"
+      surname = "givenName"
+      username = "cn"
+
+      [[servers.group_mappings]]
+      group_dn = "cn=AetherROCAdmin,cn=groups,dc=opennetworking,dc=org"
+      org_role = "Admin"
+      org_id = 1
+
+      [[servers.group_mappings]]
+      group_dn = "cn=acme,cn=groups,dc=opennetworking,dc=org"
+      org_role = "Viewer"
+      org_id = 2
+
+      [[servers.group_mappings]]
+      group_dn = "cn=starbucks,cn=groups,dc=opennetworking,dc=org"
+      org_role = "Viewer"
+      org_id = 3
 
 prometheus:
   pushgateway:


### PR DESCRIPTION
Unfortunately Organizations cannot be created through Helm Charts - only through API. 

To use, login to http://localhost:8183/grafana as "admin" 

> get the `admin` password with `kubectl get secret --namespace micro-onos aether-roc-umbrella-grafana -o jsonpath="{.data.admin-password}" | base64 --decode ; echo`

Then create these 3 orgs with these IDs:

1. Main Org (will alread exist - can be renamed to Aether)
2. Acme Inc.
3. Starbucks

You will also have to deploy the `dex-ldap-umbrella` helm chart with the LDAP server

Then you can login as user `alicea`, `daisyd`, `fredf` etc with `password`.

This is just another step along the way