### PR TITLE
aether-roc-umbrella: releasing 1.2.21 - sdcore dummy logging

### DIFF
--- a/aether-roc-umbrella/Chart.yaml
+++ b/aether-roc-umbrella/Chart.yaml
@@ -7,7 +7,7 @@ name: aether-roc-umbrella
 description: Aether ROC Umbrella chart to deploy all Aether ROC
 kubeVersion: ">=1.18.0"
 type: application
-version: 1.2.20
+version: 1.2.21
 appVersion: v0.0.0
 keywords:
   - aether

--- a/aether-roc-umbrella/values.yaml
+++ b/aether-roc-umbrella/values.yaml
@@ -179,6 +179,10 @@ sdcore-test-dummy:
         root /;
         proxy_pass http://127.0.0.1:8080/post_dummy;
       }
+      location /v1/config/5g {
+        rewrite ^/v1/config/5g/.* /v1/config/5g break;
+        proxy_pass http://127.0.0.1:8080/post_dummy;
+      }
       location = /post_dummy {
         # turn off logging here to avoid double logging
         access_log off;


### PR DESCRIPTION
this should give an output each time the sdcore is called (when 
connectivity-service "core-5g-endpoint" = "http://aether-roc-umbrella-sdcore-test-dummy/v1/config/5g"

```
10.244.0.12 - - 0.000 0.000 [03/Jul/2021:19:38:01 +0000] "POST /v1/config/5g/v1/network-slice/starbucks-newyork-cameras HTTP/1.1" 200 0 {\x0A  \x22slice-id\x22: {\x0A    \x22sst\x22: 127,\x0A    \x22sd\x22: 8284729\x0A  },\x0A  \x22qos\x22: {\x0A    \x22uplink\x22: 38997335,\x0A    \x22downlink\x22: 948091966,\x0A    \x22traffic-class\x22: \x22class-1\x22\x0A  },\x0A  \x22site-device-group\x22: [\x0A    \x22starbucks-newyork-cameras\x22\x0A  ],\x0A  \x22site-info\x22: {\x0A    \x22site-name\x22: \x22starbucks-newyork\x22,\x0A    \x22plmn\x22: {\x0A      \x22mcc\x22: \x2221\x22,\x0A      \x22mnc\x22: \x2232\x22\x0A    },\x0A    \x22gNodeBs\x22: [\x0A      {\x0A        \x22name\x22: \x22ap2_newyork_starbucks_com\x22,\x0A        \x22tac\x22: 8002\x0A      }\x0A    ],\x0A    \x22upf\x22: {\x0A      \x22upf-name\x22: \x22newyork.cameras-upf.starbucks.com\x22,\x0A      \x22upf-port\x22: 6161\x0A    }\x0A  },\x0A  \x22deny-applications\x22: [],\x0A  \x22permit-applications\x22: [\x0A    \x22starbucks-nvr\x22\x0A  ],\x0A  \x22applications-information\x22: [\x0A    {\x0A      \x22app-name\x22: \x22starbucks-nvr\x22,\x0A      \x22endpoint\x22: \x22nvr.starbucks.com/32\x22,\x0A      \x22start-port\x22: 3330,\x0A      \x22end-port\x22: 3316,\x0A      \x22protocol\x22: 17\x0A    }\x0A  ]\x0A} "-" "Go-http-client/1.1" "-"
```

the escaping of the separators is unavoidable.
Also the log contains this text twice for every POST - 1 with a shortened URL and the 2nd with the full URL