### PR TITLE
aether-roc-umbrella: releasing 1.2.22

### DIFF
--- a/aether-roc-umbrella/Chart.yaml
+++ b/aether-roc-umbrella/Chart.yaml
@@ -7,7 +7,7 @@ name: aether-roc-umbrella
 description: Aether ROC Umbrella chart to deploy all Aether ROC
 kubeVersion: ">=1.18.0"
 type: application
-version: 1.2.21
+version: 1.2.22
 appVersion: v0.0.0
 keywords:
   - aether
@@ -34,7 +34,7 @@ dependencies:
   - name: onos-config
     condition: import.onos-config.enabled
     repository: https://charts.onosproject.org
-    version: 1.2.1
+    version: 1.2.2
   - name: onos-gui
     condition: import.onos-gui.enabled
     repository: https://charts.onosproject.org
@@ -55,7 +55,7 @@ dependencies:
   - name: aether-roc-gui
     condition: import.aether-roc-gui.v3.enabled
     repository: "@sdran"
-    version: 3.0.4
+    version: 3.0.5
     alias: aether-roc-gui-v3
   - name: sdcore-adapter
     condition: import.sdcore-adapter.v2_1.enabled
@@ -65,7 +65,7 @@ dependencies:
   - name: sdcore-adapter
     condition: import.sdcore-adapter.v3.enabled
     repository: "@sdran"
-    version: 3.0.2
+    version: 3.0.5
     alias: sdcore-adapter-v3
   - name: nginx
     alias: sdcore-test-dummy

--- a/aether-roc-umbrella/templates/dashboards.yaml
+++ b/aether-roc-umbrella/templates/dashboards.yaml
@@ -8,6 +8,146 @@ metadata:
   name: {{ .Release.Name }}-dashboards-starbucks
   namespace: {{ .Release.Namespace }}
 data:
+  vcs_starbucks_all.json: |-
+    {
+      "dashboard": {
+        "annotations": {
+          "list": [
+            {
+              "builtIn": 1,
+              "datasource": "-- Grafana --",
+              "enable": true,
+              "hide": true,
+              "iconColor": "rgba(0, 211, 255, 1)",
+              "name": "Annotations & Alerts",
+              "type": "dashboard"
+            }
+          ]
+        },
+        "editable": false,
+        "gnetId": null,
+        "graphTooltip": 0,
+        "links": [],
+        "panels": [
+          {
+            "datasource": "datasource-starbucks",
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "auto",
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 9,
+              "w": 12,
+              "x": 0,
+              "y": 0
+            },
+            "id": 1,
+            "options": {
+              "legend": {
+                "calcs": [],
+                "displayMode": "list",
+                "placement": "bottom"
+              },
+              "tooltip": {
+                "mode": "single"
+              }
+            },
+            "targets": [
+              {
+                "exemplar": true,
+                "expr": "sum(vcs_jitter{vcs_id=~\"starbucks.*\"})/count(vcs_jitter{vcs_id=~\"starbucks.*\"})",
+                "format": "time_series",
+                "interval": "",
+                "legendFormat": "Jitter (ms)",
+                "queryType": "randomWalk",
+                "refId": "A"
+              },
+              {
+                "exemplar": true,
+                "expr": "sum(vcs_latency{vcs_id=~\"starbucks.*\"})/count(vcs_latency{vcs_id=~\"starbucks.*\"})",
+                "hide": false,
+                "interval": "",
+                "legendFormat": "Latency (ms)",
+                "refId": "B"
+              },
+              {
+                "exemplar": true,
+                "expr": "sum(vcs_throughput{vcs_id=~\"starbucks.*\"})/count(vcs_throughput{vcs_id=~\"starbucks.*\"})",
+                "hide": false,
+                "interval": "",
+                "legendFormat": "Throughput (kb/s)",
+                "refId": "C"
+              }
+            ],
+            "title": "VCS Starbucks All",
+            "type": "timeseries"
+          }
+        ],
+        "schemaVersion": 30,
+        "style": "dark",
+        "tags": [],
+        "templating": {
+          "list": []
+        },
+        "time": {
+          "from": "now-6h",
+          "to": "now"
+        },
+        "timepicker": {},
+        "timezone": "",
+        "title": "VCS Starbucks All",
+        "uid": "vcs_starbucks_all",
+        "version": 2
+      },
+      "folderUid": "starbucks",
+      "message": "Made changes to Starbucks"
+    }
   vcs_starbucks_newyork_cameras.json: |-
     {
       "dashboard": {
@@ -25,13 +165,13 @@ data:
           ]
         },
         "description": "",
-        "editable": true,
+        "editable": false,
         "gnetId": null,
         "graphTooltip": 0,
         "links": [],
         "panels": [
           {
-            "datasource": "datasource-Starbucks",
+            "datasource": "datasource-starbucks",
             "description": "",
             "fieldConfig": {
               "defaults": {
@@ -89,7 +229,7 @@ data:
               "x": 0,
               "y": 0
             },
-            "id": 2,
+            "id": 1,
             "links": [],
             "options": {
               "legend": {
@@ -147,7 +287,7 @@ data:
         "uid": "vcs_starbucks_newyork_cameras",
         "version": 1
       },
-      "folderUid": "Starbucks",
+      "folderUid": "starbucks",
       "message": "Made changes to Starbucks"
     }
   vcs_starbucks_seattle_cameras.json: |-
@@ -167,13 +307,13 @@ data:
           ]
         },
         "description": "",
-        "editable": true,
+        "editable": false,
         "gnetId": null,
         "graphTooltip": 0,
         "links": [],
         "panels": [
           {
-            "datasource": "datasource-Starbucks",
+            "datasource": "datasource-starbucks",
             "description": "",
             "fieldConfig": {
               "defaults": {
@@ -231,7 +371,7 @@ data:
               "x": 0,
               "y": 0
             },
-            "id": 2,
+            "id": 1,
             "links": [],
             "options": {
               "legend": {
@@ -289,16 +429,156 @@ data:
         "uid": "vcs_starbucks_seattle_cameras",
         "version": 1
       },
-      "folderUid": "Starbucks",
+      "folderUid": "starbucks",
       "message": "Made changes to Starbucks"
     }
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Release.Name }}-dashboards-acme-inc
+  name: {{ .Release.Name }}-dashboards-acme
   namespace: {{ .Release.Namespace }}
 data:
+  vcs_acme_all.json: |-
+    {
+      "dashboard": {
+        "annotations": {
+          "list": [
+            {
+              "builtIn": 1,
+              "datasource": "-- Grafana --",
+              "enable": true,
+              "hide": true,
+              "iconColor": "rgba(0, 211, 255, 1)",
+              "name": "Annotations & Alerts",
+              "type": "dashboard"
+            }
+          ]
+        },
+        "editable": false,
+        "gnetId": null,
+        "graphTooltip": 0,
+        "links": [],
+        "panels": [
+          {
+            "datasource": "datasource-acme",
+            "fieldConfig": {
+              "defaults": {
+                "color": {
+                  "mode": "palette-classic"
+                },
+                "custom": {
+                  "axisLabel": "",
+                  "axisPlacement": "auto",
+                  "barAlignment": 0,
+                  "drawStyle": "line",
+                  "fillOpacity": 0,
+                  "gradientMode": "none",
+                  "hideFrom": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": false
+                  },
+                  "lineInterpolation": "linear",
+                  "lineWidth": 1,
+                  "pointSize": 5,
+                  "scaleDistribution": {
+                    "type": "linear"
+                  },
+                  "showPoints": "auto",
+                  "spanNulls": false,
+                  "stacking": {
+                    "group": "A",
+                    "mode": "none"
+                  },
+                  "thresholdsStyle": {
+                    "mode": "off"
+                  }
+                },
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                }
+              },
+              "overrides": []
+            },
+            "gridPos": {
+              "h": 9,
+              "w": 12,
+              "x": 0,
+              "y": 0
+            },
+            "id": 1,
+            "options": {
+              "legend": {
+                "calcs": [],
+                "displayMode": "list",
+                "placement": "bottom"
+              },
+              "tooltip": {
+                "mode": "single"
+              }
+            },
+            "targets": [
+              {
+                "exemplar": true,
+                "expr": "sum(vcs_jitter{vcs_id=~\"acme.*\"})/count(vcs_jitter{vcs_id=~\"acme.*\"})",
+                "format": "time_series",
+                "interval": "",
+                "legendFormat": "Jitter (ms)",
+                "queryType": "randomWalk",
+                "refId": "A"
+              },
+              {
+                "exemplar": true,
+                "expr": "sum(vcs_latency{vcs_id=~\"acme.*\"})/count(vcs_latency{vcs_id=~\"acme.*\"})",
+                "hide": false,
+                "interval": "",
+                "legendFormat": "Latency (ms)",
+                "refId": "B"
+              },
+              {
+                "exemplar": true,
+                "expr": "sum(vcs_throughput{vcs_id=~\"acme.*\"})/count(vcs_throughput{vcs_id=~\"acme.*\"})",
+                "hide": false,
+                "interval": "",
+                "legendFormat": "Throughput (kb/s)",
+                "refId": "C"
+              }
+            ],
+            "title": "VCS Acme All",
+            "type": "timeseries"
+          }
+        ],
+        "schemaVersion": 30,
+        "style": "dark",
+        "tags": [],
+        "templating": {
+          "list": []
+        },
+        "time": {
+          "from": "now-6h",
+          "to": "now"
+        },
+        "timepicker": {},
+        "timezone": "",
+        "title": "VCS Acme All",
+        "uid": "vcs_acme_all",
+        "version": 1
+      },
+      "folderUid": "acme",
+      "message": "Made changes to Acme"
+    }
   vcs_acme_chicago_robots.json: |-
     {
       "dashboard": {
@@ -316,13 +596,13 @@ data:
           ]
         },
         "description": "",
-        "editable": true,
+        "editable": false,
         "gnetId": null,
         "graphTooltip": 0,
         "links": [],
         "panels": [
           {
-            "datasource": "datasource-Acme_Inc",
+            "datasource": "datasource-acme",
             "description": "",
             "fieldConfig": {
               "defaults": {
@@ -380,7 +660,7 @@ data:
               "x": 0,
               "y": 0
             },
-            "id": 2,
+            "id": 1,
             "links": [],
             "options": {
               "legend": {
@@ -395,14 +675,14 @@ data:
             "targets": [
               {
                 "exemplar": true,
-                "expr": "vcs_jitter{vcs_id=\"starbucks_newyork_cameras\"}",
+                "expr": "vcs_jitter{vcs_id=\"starbucks_acme_robots\"}",
                 "interval": "",
                 "legendFormat": "Jitter (ms)",
                 "refId": "A"
               },
               {
                 "exemplar": true,
-                "expr": "vcs_latency{vcs_id=\"starbucks_newyork_cameras\"}",
+                "expr": "vcs_latency{vcs_id=\"starbucks_acme_robots\"}",
                 "hide": false,
                 "interval": "",
                 "legendFormat": "Latency (ms)",
@@ -410,7 +690,7 @@ data:
               },
               {
                 "exemplar": true,
-                "expr": "vcs_throughput{vcs_id=\"starbucks_newyork_cameras\"}",
+                "expr": "vcs_throughput{vcs_id=\"starbucks_acme_robots\"}",
                 "hide": false,
                 "interval": "",
                 "legendFormat": "Throughput (kb/s)",
@@ -438,6 +718,6 @@ data:
         "uid": "vcs_acme_chicago_robots",
         "version": 1
       },
-      "folderUid": "Acme_Inc",
+      "folderUid": "acme",
       "message": "Made changes to Acme"
     }

--- a/aether-roc-umbrella/templates/post-install-job-grafana.yaml
+++ b/aether-roc-umbrella/templates/post-install-job-grafana.yaml
@@ -56,10 +56,10 @@ spec:
               mountPath: /usr/local/bin
               readOnly: true
             - name: dashboards-starbucks
-              mountPath: /usr/local/dashboards/Starbucks
+              mountPath: /usr/local/dashboards/starbucks
               readOnly: true
-            - name: dashboards-acme-inc
-              mountPath: /usr/local/dashboards/Acme_Inc
+            - name: dashboards-acme
+              mountPath: /usr/local/dashboards/acme
               readOnly: true
       volumes:
         - name: post-install
@@ -69,7 +69,7 @@ spec:
         - name: dashboards-starbucks
           configMap:
             name: {{ template "aether-roc-api.fullname" . }}-dashboards-starbucks
-        - name: dashboards-acme-inc
+        - name: dashboards-acme
           configMap:
-            name: {{ template "aether-roc-api.fullname" . }}-dashboards-acme-inc
+            name: {{ template "aether-roc-api.fullname" . }}-dashboards-acme
 

--- a/aether-roc-umbrella/values.yaml
+++ b/aether-roc-umbrella/values.yaml
@@ -114,8 +114,8 @@ sdcore-adapter-v3:
 
 grafana:
   orgs:
-    - "Acme Inc"
-    - "Starbucks"
+    - "acme"
+    - "starbucks"
   tidyUpPostInstall: true
   grafana.ini:
     log:


### PR DESCRIPTION
- Updates `onos-config` form AETHER-1950 and 1951
- Updates `aether-roc-gui` with Prometheus and Grafana improvents and many others
- Updates `sdcore-exporter` with solution for metrics falling slowly
- Adds new Grafana dashboards for VCS summary per Enterprise