### PR TITLE
aether-roc-umbrella: releasing 1.2.23

### DIFF
--- a/aether-roc-umbrella/Chart.yaml
+++ b/aether-roc-umbrella/Chart.yaml
@@ -7,7 +7,7 @@ name: aether-roc-umbrella
 description: Aether ROC Umbrella chart to deploy all Aether ROC
 kubeVersion: ">=1.18.0"
 type: application
-version: 1.2.22
+version: 1.2.23
 appVersion: v0.0.0
 keywords:
   - aether
@@ -46,7 +46,7 @@ dependencies:
   - name: aether-roc-api
     condition: import.aether-roc-api.enabled
     repository: "@sdran"
-    version: 1.0.7
+    version: 1.0.8
   - name: aether-roc-gui
     condition: import.aether-roc-gui.v2_1.enabled
     repository: "@sdran"

--- a/aether-roc-umbrella/templates/dashboards.yaml
+++ b/aether-roc-umbrella/templates/dashboards.yaml
@@ -675,14 +675,14 @@ data:
             "targets": [
               {
                 "exemplar": true,
-                "expr": "vcs_jitter{vcs_id=\"starbucks_acme_robots\"}",
+                "expr": "vcs_jitter{vcs_id=\"acme_chicago_robots\"}",
                 "interval": "",
                 "legendFormat": "Jitter (ms)",
                 "refId": "A"
               },
               {
                 "exemplar": true,
-                "expr": "vcs_latency{vcs_id=\"starbucks_acme_robots\"}",
+                "expr": "vcs_latency{vcs_id=\"acme_chicago_robots\"}",
                 "hide": false,
                 "interval": "",
                 "legendFormat": "Latency (ms)",
@@ -690,7 +690,7 @@ data:
               },
               {
                 "exemplar": true,
-                "expr": "vcs_throughput{vcs_id=\"starbucks_acme_robots\"}",
+                "expr": "vcs_throughput{vcs_id=\"acme_chicago_robots\"}",
                 "hide": false,
                 "interval": "",
                 "legendFormat": "Throughput (kb/s)",

--- a/aether-roc-umbrella/values.yaml
+++ b/aether-roc-umbrella/values.yaml
@@ -147,6 +147,7 @@ prometheus:
     prometheus.yml:
       scrape_configs:
         - job_name: sdcore-exporter
+          scrape_interval: 2s
           static_configs:
             - targets:
                 - sdcore-adapter-v3-exporter:2112
@@ -330,6 +331,7 @@ onos-config:
 
           ip_domains[ip_domain] {
             ip_domain := input.ip_domain.ip_domain[_]
+            ["AetherROCAdmin", ip_domain.enterprise][_] == input.groups[i]
           }
 
           networks[network] {


### PR DESCRIPTION
- correct error in ACME dashboard
- add in `enterprise` RBAC for `ip-domain`
- bump `aether-roc-api` to `1.0.8`
- recuded the Prometheus `scrape` interval from 1 min to 2 seconds