### PR TITLE
Update fb-ah-gui helm. Add Configuration for Google Maps API Key.

### DIFF
--- a/fb-ah-gui/Chart.yaml
+++ b/fb-ah-gui/Chart.yaml
@@ -7,8 +7,8 @@ name: fb-ah-gui
 description: FB AirHop GUI
 kubeVersion: ">=1.17.0"
 type: application
-version: 0.0.2
-appVersion: 0.0.2
+version: 0.0.3
+appVersion: 0.0.3
 keywords:
   - fb
 home: https://connectivity.fb.com/

--- a/fb-ah-gui/templates/deployment.yaml
+++ b/fb-ah-gui/templates/deployment.yaml
@@ -36,7 +36,9 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          #args:
+          args:
+            - "main.py"
+            - "--gmaps_api_key={{ .Values.config.gmapsApiKey }}"
           ports:
             - name: http
               containerPort: {{ .Values.service.http.port }}

--- a/fb-ah-gui/values.yaml
+++ b/fb-ah-gui/values.yaml
@@ -20,6 +20,9 @@ fullnameOverride: "fb-ah-gui"
 
 storage: {}
 
+config:
+  gmapsApiKey: ""
+
 service:
   http:
     port: 8080


### PR DESCRIPTION
The latest version of `fb-ah-gui` allow the Google Maps API key to be specified via CLI flag. This updated helm chart adds `Values.config.gmapsApiKey` for specifying the API key in helm.