### PR TITLE
Add flags to optionally skip sending e2 control messages to avoid downstream incompatibility

### DIFF
--- a/fb-ah-xapp/Chart.yaml
+++ b/fb-ah-xapp/Chart.yaml
@@ -7,8 +7,8 @@ name: fb-ah-xapp
 description: FB AirHop eSON xApp Adapter
 kubeVersion: ">=1.17.0"
 type: application
-version: 0.0.5
-appVersion: 0.0.4
+version: 0.0.6
+appVersion: 0.0.5
 keywords:
   - onos
   - sdn

--- a/fb-ah-xapp/templates/deployment.yaml
+++ b/fb-ah-xapp/templates/deployment.yaml
@@ -57,6 +57,12 @@ spec:
 {{- if .Values.config.capacityUpdatePeriod }}
             - "--mlb-update-capacity-period={{ .Values.config.capacityUpdatePeriod }}"
 {{- end }}
+{{- if .Values.config.pciDisableControl }}
+            - "--pci-disable-control"
+{{- end }}
+{{- if .Values.config.mlbDisableControl }}
+            - "--mlb-disable-control"
+{{- end }}
           ports:
             - name: http
               containerPort: 8080

--- a/fb-ah-xapp/values.yaml
+++ b/fb-ah-xapp/values.yaml
@@ -10,7 +10,7 @@ replicaCount: 1
 
 image:
   repository: onosproject/fb-ah-xapp
-  tag: 0.0.4
+  tag: 0.0.5
   pullPolicy: IfNotPresent
   pullSecrets: []
 
@@ -33,6 +33,12 @@ config:
   processingDelay: 0
   # period of update of capacity information to eson (seconds)
   capacityUpdatePeriod: 10
+  # when airhop change requests are received, do not send pci e2 control messages
+  #   (curl -X POST host:8080/pci?items=0x13842601454c003,164 still works)
+  pciDisableControl: false
+  # when airhop change requests are received, do not send mlb (ocn) e2 control messages
+  #   (curl -X POST host:8080/cio?items=0x1384274550001,0x1384274550003,5 still works)
+  mlbDisableControl: false
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
E2 device may not support pci or ocn control messages, support for these flags added to app