### PR TITLE
aether-roc-umbrella: releasing 1.2.39 to upgrade components

### DIFF
--- a/aether-roc-umbrella/Chart.yaml
+++ b/aether-roc-umbrella/Chart.yaml
@@ -7,7 +7,7 @@ name: aether-roc-umbrella
 description: Aether ROC Umbrella chart to deploy all Aether ROC
 kubeVersion: ">=1.18.0"
 type: application
-version: 1.2.38
+version: 1.2.39
 appVersion: v0.0.0
 keywords:
   - aether
@@ -20,7 +20,7 @@ dependencies:
   - name: onos-topo
     condition: import.onos-topo.enabled
     repository: https://charts.onosproject.org
-    version: 1.0.15
+    version: 1.1.100
   - name: config-model-aether
     condition: onos-config.models.aether.v2_1.enabled
     repository: "@sdran"
@@ -34,7 +34,7 @@ dependencies:
   - name: onos-config
     condition: import.onos-config.enabled
     repository: https://charts.onosproject.org
-    version: 1.2.3
+    version: 1.3.0
   - name: onos-gui
     condition: import.onos-gui.enabled
     repository: https://charts.onosproject.org
@@ -42,7 +42,7 @@ dependencies:
   - name: onos-cli
     condition: import.onos-cli.enabled
     repository: https://charts.onosproject.org
-    version: 1.0.26
+    version: 1.1.3
   - name: aether-roc-api
     condition: import.aether-roc-api.enabled
     repository: "@sdran"
@@ -75,8 +75,8 @@ dependencies:
   - name: grafana
     condition: import.grafana.enabled
     repository: https://grafana.github.io/helm-charts
-    version: 6.13.5
+    version: 6.15.0
   - name: prometheus
     condition: import.prometheus.enabled
     repository: https://prometheus-community.github.io/helm-charts
-    version: 14.2.1
+    version: 14.6.0


### PR DESCRIPTION
Upgraded:

- `onos-topo` to 1.1.100
- `onos-config` to 1.3.0
- `onos-cli` to 1.1.3
- `prometheus` to 14.6.0
- `grafana` to 6.15.0