### PR TITLE
aether-roc-umbrella: releasing 1.3.0 for new atomix controller

### DIFF
--- a/aether-roc-umbrella/Chart.yaml
+++ b/aether-roc-umbrella/Chart.yaml
@@ -7,7 +7,7 @@ name: aether-roc-umbrella
 description: Aether ROC Umbrella chart to deploy all Aether ROC
 kubeVersion: ">=1.18.0"
 type: application
-version: 1.2.46
+version: 1.3.0
 appVersion: v0.0.0
 keywords:
   - aether


### PR DESCRIPTION
There is a page that links the Atomix and Onos Operator dependenices at

https://docs.aetherproject.org/master/developer/roc.html#installing-prerequisites

Because this Helm chart has new dependencies, I'm bumping it to 1.3.0