### PR TITLE
bump image tag version of fb-ah-xapp

### DIFF
--- a/ah-eson-test-server/Chart.yaml
+++ b/ah-eson-test-server/Chart.yaml
@@ -7,8 +7,8 @@ name: ah-eson-test-server
 description: FB ah-eson-test-server
 kubeVersion: ">=1.17.0"
 type: application
-version: 0.0.3
-appVersion: 0.0.3
+version: 0.0.2
+appVersion: 0.0.2
 keywords:
   - onos
   - sdn

--- a/ah-eson-test-server/values.yaml
+++ b/ah-eson-test-server/values.yaml
@@ -9,7 +9,7 @@ replicaCount: 1
 
 image:
   repository: onosproject/ah-eson-test-server
-  tag: 0.0.3
+  tag: 0.0.2
   pullPolicy: IfNotPresent
   pullSecrets: []
 


### PR DESCRIPTION
point at new images built from code in https://github.com/onosproject/onos-ric-python-apps
for https://hub.docker.com/r/onosproject/fb-ah-xapp/tags/