### PR TITLE
Adds fix to rel-1.2 sd-ran values for opensearch

### DIFF
--- a/sd-ran/Chart.yaml
+++ b/sd-ran/Chart.yaml
@@ -7,8 +7,8 @@ name: sd-ran
 description: Umbrella chart to deploy all ONOS-RIC and simulator
 kubeVersion: ">=1.17.0"
 type: application
-version: 1.2.3
-appVersion: v1.2.3
+version: 1.2.4
+appVersion: v1.2.4
 keywords:
   - onos
   - sdn

--- a/sd-ran/values.yaml
+++ b/sd-ran/values.yaml
@@ -78,7 +78,7 @@ import:
     enabled: false
   fluent-bit:
     enabled: false
-  opendistro-es:
+  opensearch:
     enabled: false
   prometheus-stack:
     enabled: false
@@ -227,24 +227,9 @@ prometheus-stack:
     - sdran.json
     - sdran-kpis.json
 
-opendistro-es:
-  elasticsearch:
-    config:
-      opendistro_security.disabled: true
-    master:
-      persistence:
-        enabled: false
-    data:
-      persistence:
-        enabled: false
-  kibana:
-    # image: amazon/opendistro-for-elasticsearch-kibana-no-security
-    # imagePullPolicy: IfNotPresent
-    externalPort: 5601
-    config:
-      elasticsearch.hosts: http://sd-ran-opendistro-es-client-service:9200
-      elasticsearch.requestTimeout: 360000
-      server.ssl.enabled: false
+opensearch:
+  persistence:
+    enabled: false
 
 fluent-bit:
   config:


### PR DESCRIPTION
Sets persistence false in opensearch - no need for storage
persistence avoids crashloopback in opensearch pods