### PR TITLE
Fix security context profile

### DIFF
--- a/onos-uenib/Chart.yaml
+++ b/onos-uenib/Chart.yaml
@@ -7,7 +7,7 @@ name: onos-uenib
 description: ONOS UE-NIB Subsystem
 kubeVersion: ">=1.17.0"
 type: application
-version: 1.3.1
+version: 1.3.2
 appVersion: v0.2.5
 keywords:
   - onos

--- a/onos-uenib/templates/deployment.yaml
+++ b/onos-uenib/templates/deployment.yaml
@@ -26,7 +26,6 @@ spec:
         resource: {{ template "onos-uenib.fullname" . }}
         {{- include "onos-uenib.selectorLabels" . | nindent 8 }}
       annotations:
-        seccomp.security.alpha.kubernetes.io/pod: "unconfined"
         broker.atomix.io/inject: "true"
         raft.storage.atomix.io/inject: "true"
     spec:

--- a/onos-uenib/values.yaml
+++ b/onos-uenib/values.yaml
@@ -85,3 +85,7 @@ logging:
     stdout:
       type: stdout
       stdout: {}
+
+podSecurityContext:
+  seccompProfile:
+    type: "Unconfined"

--- a/sd-ran/Chart.yaml
+++ b/sd-ran/Chart.yaml
@@ -7,7 +7,7 @@ name: sd-ran
 description: Umbrella chart to deploy all ONOS-RIC and simulator
 kubeVersion: ">=1.17.0"
 type: application
-version: 1.4.106
+version: 1.4.107
 appVersion: v1.4.0
 keywords:
   - onos
@@ -37,11 +37,11 @@ dependencies:
   - name: onos-topo
     condition: import.onos-topo.enabled
     repository: https://charts.onosproject.org
-    version: 1.3.1
+    version: 1.3.3
   - name: onos-uenib
     condition: import.onos-uenib.enabled
     repository: file://../onos-uenib
-    version: 1.3.1
+    version: 1.3.2
   - name: onos-config
     condition: import.onos-config.enabled
     repository: https://charts.onosproject.org


### PR DESCRIPTION
This fixes the deprecation warning:

spec.template.metadata.annotations[seccomp.security.alpha.kubernetes.io/pod]: deprecated since v1.19, non-functional in v1.25+; use the "seccompProfile" field instead
